### PR TITLE
Fix build on Windows

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -3,7 +3,8 @@ default_target: all
 .PHONY: clean force all
 
 # absolute paths so that emacs compile mode knows where to find error
-SRCDIR := $(shell pwd)/src
+# use cygpath -m because Coq on Windows cannot handle cygwin paths
+SRCDIR := $(shell cygpath -m "$$(pwd)" 2>/dev/null || pwd)/src
 
 ALL_VS := $(shell find $(SRCDIR) -type f -name '*.v')
 


### PR DESCRIPTION
Coq on Windows generally does not support paths like `/cygdrive/d/Documents/GitHub/bedrock2/deps/coqutil/src/Datatypes/HList.v`.  These are the sorts of paths generated by `pwd` / `find` under cygwin, unless you run the initial path through `cygpath -m` (`-m` for mixed, which makes it use forward slashes).  We pipe stderr to `/dev/null` and fallback to `pwd` on platforms where `cygpath` is not in path (i.e., non-windows platforms).