### PR TITLE
Avoid relying on `Export` bugs

### DIFF
--- a/src/Word/Properties.v
+++ b/src/Word/Properties.v
@@ -1,4 +1,4 @@
-Require Import Coq.ZArith.BinInt.
+Require Import Coq.ZArith.BinInt Ring.
 Require Import coqutil.Z.div_mod_to_equations.
 Require Import coqutil.Z.Lia Btauto.
 Require Coq.setoid_ring.Ring_theory.


### PR DESCRIPTION
See https://github.com/coq/coq/issues/10474 and
https://github.com/coq/coq/issues/10480

This is in preparation for coq/coq#10476 which fixes these two bugs, and is backward compatible (tested on Coq's master).