### PR TITLE
Avoid relying on `Export` bugs (again)

### DIFF
--- a/src/Word/Properties.v
+++ b/src/Word/Properties.v
@@ -1,4 +1,4 @@
-Require Import Coq.ZArith.BinInt Ring.
+From Coq Require Import ZArith.
 Require Import coqutil.Z.div_mod_to_equations.
 Require Import coqutil.Z.Lia Btauto.
 Require Import coqutil.Z.PushPullMod.


### PR DESCRIPTION
This is still for https://github.com/coq/coq/pull/10476.

To avoid new breakage, I'd recommend to avoid importing internal stdlib files, but rather interface at the intended points (typically, `ZArith` rather than `BinInt` and `Ring`).