### PR TITLE
Update gitignore after coq/coq#11075

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -3,6 +3,7 @@ Makefile.coq.*
 .Makefile.coq.*
 *.vo
 *.vos
+*.vok
 *~
 *.glob
 *.aux


### PR DESCRIPTION
Empty vok files are now also generated during normal compilation (in addition to the empty vos files); see coq/coq#11075.