### PR TITLE
Avoid using admit even in tests

### DIFF
--- a/src/coqutil/Macros/symmetry.v
+++ b/src/coqutil/Macros/symmetry.v
@@ -12,14 +12,15 @@ Ltac exact_sym_under_binders pf :=
 Notation "symmetry! pf" := (ltac:(exact_sym_under_binders pf))
                              (at level 10, only parsing).
 
-Goal forall y, exists x, 1 + S y = x.
-  assert (forall y z, z = y+y -> y+y=z) as H by admit.
+Goal (forall y z, z = y+y -> y+y=z) ->
+     (forall y, let z := y+y in y+y=z) ->
+     (forall y, let z := y+y in forall t, t+y+y=t+z) ->
+     forall y, exists x, 1 + S y = x.
+Proof.
+  intros H HH HHH.
+
   pose proof (symmetry! H).
-
-  assert (forall y, let z := y+y in y+y=z) as HH by admit.
   pose proof (symmetry! HH).
-
-  assert (forall y, let z := y+y in forall t, t+y+y=t+z) as HHH by admit.
   pose proof (symmetry! HHH).
 
   pose proof (symmetry! (fun pf : 1 = 2 => pf)).


### PR DESCRIPTION
This ensures that grepping the source for admits comes back clean.