### PR TITLE
Encoding functions with finite support as maps

### DIFF
--- a/src/coqutil/Datatypes/List.v
+++ b/src/coqutil/Datatypes/List.v
@@ -9,6 +9,10 @@ Require Import Coq.Sorting.Permutation.
 
 Section WithA.
   Context {A : Type}.
+  Definition Znth_error {A} (xs : list A) z :=
+    if BinInt.Z.ltb z BinInt.Z0 then None
+    else List.nth_error xs (BinInt.Z.to_nat z).
+
   Fixpoint option_all (xs : list (option A)) {struct xs} : option (list A) :=
     match xs with
     | nil => Some nil

--- a/src/coqutil/Map/Interface.v
+++ b/src/coqutil/Map/Interface.v
@@ -41,6 +41,11 @@ Module map.
   Section WithMap.
     Context {key value : Type} {map : map key value} {map_ok : ok map}.
 
+    Definition update (m : map) (k : key) (ov : option value) :=
+      match ov with
+      | None => remove m k
+      | Some v => put m k v
+      end.
     Definition putmany: map -> map -> map := fold put.
     Definition extends (m1 m2 : map) := forall x w, get m2 x = Some w -> get m1 x = Some w.
     Definition agree_on (P : set key) m1 m2 := forall k, elem_of k P -> get m1 k = get m2 k.

--- a/src/coqutil/Map/MapKeys.v
+++ b/src/coqutil/Map/MapKeys.v
@@ -1,0 +1,50 @@
+Require Import coqutil.Decidable coqutil.Map.Interface.
+Require coqutil.Decidable coqutil.Map.Properties.
+Import Interface.map.
+
+Module map.
+  Section MapKeys.
+    Context {key value} {map : map key value} {ok : map.ok map}.
+    Context {key_eqb: key -> key -> bool} {key_eq_dec: EqDecider key_eqb}.
+    Context {key'} {map' : Interface.map.map key' value} {ok' : map.ok map'}.
+    Context {key'_eqb: key' -> key' -> bool} {key'_eq_dec: EqDecider key'_eqb}.
+
+    Definition map_keys f (m:map) : map' := fold (fun m k v => put m (f k) v) empty m.
+    Lemma get_map_keys_invertible (f : key -> key') m k
+      (H:forall k' v', get m k' = Some v' -> f k = f k' -> get m k = get m k')
+      : get (map_keys f m) (f k) = get m k.
+    Proof.
+      revert dependent k.
+      cbv [map_keys].
+      refine (fold_spec (fun m r => forall k,
+        (forall k' v', get m k' = Some v' -> f k = f k' -> get m k = get m k') ->
+        get r (f k) = get m k) _ empty _ _ m).
+      { intros; rewrite ?get_empty; trivial. }
+      clear m.
+      intros knew vnew m r Hknew HI k Hk.
+      destruct (key_eq_dec k knew) as [HR|HR]; [rewrite <-!HR in *; clear HR|].
+      { rewrite 2get_put_same; trivial. }
+      rewrite (get_put_diff m k _ _) by congruence.
+      destruct (key'_eq_dec (f k) (f knew)) as [HW|HW]; rewrite <-?HW in *.
+      { unshelve epose proof Hk knew vnew _ HW.
+        { rewrite get_put_same; trivial. }
+        rewrite get_put_same, get_put_diff in H; trivial; rewrite H.
+        eauto using get_put_same. }
+      rewrite get_put_diff by trivial.
+      eapply HI.
+      intros ? ? Hm Hf.
+      specialize (Hk k' v').
+      destruct (key_eq_dec k' knew); subst.
+      { rewrite Hknew in Hm; inversion Hm. }
+      rewrite 2get_put_diff in Hk by assumption; eauto.
+    Qed.
+
+    Lemma get_map_keys_always_invertible (f : key -> key')
+      (H : forall k k', f k = f k' -> k = k')
+      : forall m k, get (map_keys f m) (f k) = get m k.
+    Proof.
+      intros. eapply get_map_keys_invertible. intros ? ? HA HB.
+      rewrite (H _ _ HB); trivial.
+    Qed.
+  End MapKeys.
+End map.

--- a/src/coqutil/Map/OfFunc.v
+++ b/src/coqutil/Map/OfFunc.v
@@ -1,0 +1,129 @@
+Require Import coqutil.Decidable coqutil.Map.Interface coqutil.Map.MapKeys.
+Require coqutil.Decidable coqutil.Map.Properties.
+Require Coq.Lists.List.
+Import MapKeys.map Interface.map.
+
+Module map.
+  Section OfFunc.
+    Context {key value} {map : map key value} {ok : map.ok map}.
+    Context {key_eqb: key -> key -> bool} {key_eq_dec: EqDecider key_eqb}.
+
+    Context (f : key -> option value).
+    Fixpoint of_func (support : list key) : map :=
+      match support with
+      | nil => empty
+      | cons k support => update (of_func support) k (f k)
+      end.
+
+    Lemma get_of_func_In k support (Hs : List.In k support)
+      : get (of_func support) k = f k.
+    Proof.
+      revert dependent support.
+      induction support.
+      { firstorder idtac. }
+      { destruct (key_eq_dec a k); intros [|]; subst;
+          pose proof Properties.map.get_update_same;
+          cbn; try congruence; [].
+        rewrite Properties.map.get_update_diff by congruence.
+        eauto. }
+    Qed.
+
+    Lemma get_of_func_Some_In k support v (H:get (of_func support) k = Some v)
+      : List.In k support.
+    Proof.
+      revert dependent support.
+      induction support.
+      { cbn. rewrite get_empty. discriminate. }
+      { destruct (key_eq_dec a k); subst; cbn [List.In of_func]; eauto.
+        rewrite Properties.map.get_update_diff by congruence; eauto. }
+    Qed.
+
+    Lemma get_of_func_notIn k support (Hs : not (List.In k support))
+      : get (of_func support) k = None.
+    Proof.
+      case (get (of_func support) k) eqn:H; trivial.
+      eapply get_of_func_Some_In in H; intuition.
+    Qed.
+
+    Lemma get_of_func_None k s (H:f k = None) : get (of_func s) k = None.
+    Proof.
+      induction s.
+      { firstorder idtac. }
+      { destruct (key_eq_dec a k); subst.
+        { cbn [of_func]. cbv [update].
+          rewrite H, get_remove_same; trivial. }
+        { cbn; rewrite Properties.map.get_update_diff; congruence. } }
+    Qed.
+
+    Lemma get_of_func_Some_supported_In
+      support (Hs : forall k v, f k = Some v -> List.In k support)
+      k v (Hk : f k = Some v)
+      : get (of_func support) k = f k.
+    Proof. eauto using get_of_func_In. Qed.
+
+    Lemma get_of_func_Some_supported
+      support (Hs : forall k v, f k = Some v -> List.In k support) k
+      : get (of_func support) k = f k.
+    Proof.
+      case (f k) eqn:H.
+      { pose proof get_of_func_Some_supported_In _ Hs _ _ H; congruence. }
+      { eauto using get_of_func_None. }
+    Qed.
+
+    Lemma get_of_func_type_supported k support (Hs : forall k, List.In k support) 
+      : get (of_func support) k = f k.
+    Proof. eauto using get_of_func_In. Qed.
+  End OfFunc.
+
+  Import Coq.Lists.List coqutil.Datatypes.List Interface.map.
+  Section OfListNatAt.
+    Context {value : Type} {map : map nat value} {ok : map.ok map}.
+    Definition of_list_nat (xs : list value) : map :=
+      of_func (nth_error xs) (seq 0 (length xs)).
+    Definition of_list_nat_at (a : nat) (xs : list value) : map :=
+      map_keys (Nat.add a) (of_list_nat xs).
+
+    Lemma get_of_list_nat xs i : get (of_list_nat xs) i = nth_error xs i.
+    Proof.
+      pose proof Nat.eqb_spec.
+      cbv [of_list_nat].
+      erewrite get_of_func_Some_supported; trivial; intros.
+      rewrite in_seq; split; try Lia.lia; cbn.
+      apply nth_error_Some. congruence.
+    Qed.
+
+    Lemma get_of_list_nat_at a xs i : get (of_list_nat_at a xs) (a+i) = nth_error xs i.
+    Proof.
+      cbv [of_list_nat_at].
+      rewrite get_map_keys_always_invertible, get_of_list_nat; trivial; intros; Lia.lia.
+    Qed.
+  End OfListNatAt.
+
+  Section OfListZAt.
+    Import BinInt.
+    Context {value : Type} {map : map Z value} {ok : map.ok map}.
+    Definition of_list_Z (xs : list value) : map :=
+      of_func (Znth_error xs) (List.map Z.of_nat (seq 0 (length xs))).
+    Definition of_list_Z_at (a : Z) (xs : list value) : map :=
+      map_keys (Z.add a) (of_list_Z xs).
+
+    Lemma get_of_list_Z xs i : get (of_list_Z xs) i = Znth_error xs i.
+    Proof.
+      pose proof Decidable.Z.eqb_spec.
+      cbv [Znth_error of_list_Z].
+      erewrite get_of_func_Some_supported; trivial; intros.
+      destruct (Z.ltb_spec k 0%Z) in *; try discriminate.
+      eapply in_map_iff; exists (Z.to_nat k); rewrite ?in_seq;
+        repeat split; rewrite ?Znat.Z2Nat.id; try Lia.lia; cbn.
+      apply nth_error_Some. congruence.
+    Qed.
+
+    Lemma get_of_list_Z_at a xs i : get (of_list_Z_at a xs) i = Znth_error xs (i-a)%Z.
+    Proof.
+      cbv [of_list_Z_at].
+      replace i with (a+(i-a))%Z by Lia.lia.
+      rewrite get_map_keys_always_invertible, get_of_list_Z by (intros; Lia.lia).
+      f_equal; Lia.lia.
+    Qed.
+  End OfListZAt.
+End map.

--- a/src/coqutil/Map/OfListWord.v
+++ b/src/coqutil/Map/OfListWord.v
@@ -1,0 +1,54 @@
+Require Import ZArith.
+Require Import Coq.Lists.List coqutil.Datatypes.List.
+Require Import coqutil.Map.Interface coqutil.Map.OfFunc.
+Import Interface.map MapKeys.map OfFunc.map.
+Require Import coqutil.Word.Interface coqutil.Word.Properties.
+
+Module map.
+  Section __.
+    Context {width} {word : word width} {word_ok : word.ok word}.
+    Add Ring __wring: (@word.ring_theory width word word_ok).
+    Context {value : Type} {map : map word value} {ok : map.ok map}.
+
+    Definition of_list_word (xs : list value) : map :=
+      map.of_func
+      (fun w => nth_error xs (Z.to_nat (word.unsigned w)))
+      (List.map (fun n => word.of_Z (Z.of_nat n)) (seq 0 (length xs))).
+    Definition of_list_word_at (a : word) (xs : list value) : map :=
+      map_keys (word.add a) (of_list_word xs).
+    Lemma get_of_list_word xs i : get (of_list_word xs) i
+      = nth_error xs (Z.to_nat (word.unsigned i)).
+    Proof.
+      pose proof word.eqb_spec.
+      cbv [of_list_word].
+      erewrite get_of_func_Some_supported; trivial; intros.
+      pose proof word.unsigned_range k.
+      eapply in_map_iff; exists (Z.to_nat (word.unsigned k));
+        rewrite ?in_seq; repeat split; rewrite ?Znat.Z2Nat.id;
+        try Lia.lia; try solve [eapply word.of_Z_unsigned].
+      apply nth_error_Some. congruence.
+    Qed.
+    Lemma get_of_list_word_at a xs i : get (of_list_word_at a xs) i
+      = nth_error xs (Z.to_nat (word.unsigned (word.sub i a))).
+    Proof.
+      cbv [of_list_word_at].
+      replace i with (word.add a (word.sub i a)) by ring.
+      rewrite get_map_keys_always_invertible, get_of_list_word.
+      2: { intros ? ? H.
+           assert (A:word.sub (word.add a k) a = word.sub (word.add a k') a).
+           { rewrite H; trivial. }
+           ring_simplify in A; exact A. }
+      f_equal. f_equal. f_equal. ring.
+    Qed.
+
+    Lemma get_of_list_word_at_domain a xs i :
+      get (of_list_word_at a xs) i <> None
+      <->
+      (0 <= word.unsigned (word.sub i a) < Z.of_nat (length xs))%Z.
+    Proof.
+      pose proof word.unsigned_range (word.sub i a).
+      rewrite get_of_list_word_at, nth_error_Some.
+      rewrite Nat2Z.inj_lt, ?Znat.Z2Nat.id; intuition.
+    Qed.
+  End __.
+End map.

--- a/src/coqutil/Map/Properties.v
+++ b/src/coqutil/Map/Properties.v
@@ -23,6 +23,11 @@ Module map.
       subst;
       eauto with map_spec_hints_separate.
 
+    Lemma get_update_same m k ov : get (update m k ov) k = ov.
+    Proof. case ov as [v|]; eauto using get_put_same, get_remove_same. Qed.
+    Lemma get_update_diff m k k' ov (H:k' <> k) : get (update m k ov) k' = get m k'.
+    Proof. case ov as [v|]; cbn; eauto using get_put_diff, get_remove_diff. Qed.
+
     Lemma get_remove_dec m x y : get (remove m x) y = if key_eqb x y then None else get m y.
     Proof. prover. Qed.
     Lemma get_put_dec m x y v : get (put m x v) y = if key_eqb x y then Some v else get m y.


### PR DESCRIPTION
Currently implemented:

- lists as maps with nat keys
- lists as maps with nat keys with some nat offset
- lists as maps with Z keys
- lists as maps with Z keys with some Z offset
- lists as maps with word keys
- lists as maps with word keys with some word offset

The main advantage of this construction is that it has a complete `get` law for the resulting maps, allowing to prove integer bounds on an address that was found to be within the constructed memory.

Please skim the definitions to check that they match your understanding of what we want in coqutil.