### PR TITLE
Future proof ZLib.v and div_mod_to_equations.v

### DIFF
--- a/src/coqutil/Z/ZLib.v
+++ b/src/coqutil/Z/ZLib.v
@@ -27,7 +27,8 @@ Module Z.
   Qed.
 
   Lemma mod_0_r: forall (m: Z),
-      m mod 0 = 0.
+      m mod 0 = 
+      ltac:(match eval hnf in (1 mod 0) with | 0 => exact 0 | _ => exact m end).
   Proof.
     intros. destruct m; reflexivity.
   Qed.
@@ -72,7 +73,7 @@ Module Z.
 
   Lemma mod_pow2_same_cases: forall a n,
       a mod 2 ^ n = a ->
-      2 ^ n = 0 /\ a = 0 \/ 0 <= a < 2 ^ n.
+      2 ^ n = 0 \/ 0 <= a < 2 ^ n.
   Proof.
     intros.
     assert (n < 0 \/ 0 <= n) as C by blia. destruct C as [C | C].

--- a/src/coqutil/Z/div_mod_to_equations.v
+++ b/src/coqutil/Z/div_mod_to_equations.v
@@ -10,7 +10,8 @@ Local Open Scope Z_scope.
     faster. *)
 
 Module Z.
-  Lemma mod_0_r_ext x y : y = 0 -> x mod y = 0.
+  Lemma mod_0_r_ext x y : y = 0 -> x mod y =
+    ltac:(match eval hnf in (1 mod 0) with | 0 => exact 0 | _ => exact x end).
   Proof. intro; subst; destruct x; reflexivity. Qed.
   Lemma div_0_r_ext x y : y = 0 -> x / y = 0.
   Proof. intro; subst; destruct x; reflexivity. Qed.


### PR DESCRIPTION
This PR makes ZLib.v and div_mod_to_equations.v work with https://github.com/coq/coq/pull/14086 in a backwards compatible manner.