### PR TITLE
Partial compatibility with Coq 8.12

### DIFF
--- a/src/coqutil/Tactics/eplace.v
+++ b/src/coqutil/Tactics/eplace.v
@@ -1,14 +1,19 @@
 (* COQBUG: https://github.com/coq/coq/issues/4494 *)
 (* COQBUG: https://github.com/coq/coq/issues/14124 *)
 
+(* Work around type inference issue in Coq <= 8.12 *)
+Ltac eplace_sym_hyp Hrw :=
+  lazymatch type of Hrw with
+  | @eq ?A ?x ?y => constr:(@eq_sym A x y Hrw)
+  end.
 Ltac eplace_with_at_by lhs rhs set_tac tac :=
   let LHS := fresh "_eplace_with_at_by_LHS" in set_tac LHS lhs;
   let Hrw := fresh "_eplace_with_at_by_Hrw" in assert (Hrw : LHS = rhs) by (subst LHS; tac);
-  clearbody LHS; induction (eq_sym Hrw); clear Hrw.
+  clearbody LHS; let Hrw' := eplace_sym_hyp Hrw in induction Hrw'; clear Hrw.
 Ltac eplace_with_at lhs rhs set_tac :=
   let LHS := fresh "_eplace_with_at_LHS" in set_tac LHS lhs;
   let Hrw := fresh "_eplace_with_at_Hrw" in assert (Hrw : LHS = rhs);
-  [subst LHS | clearbody LHS; induction (eq_sym Hrw); clear Hrw ].
+  [subst LHS | clearbody LHS; let Hrw' := eplace_sym_hyp Hrw in induction Hrw'; clear Hrw ].
 
 Tactic Notation "eplace" uconstr(x) "with" open_constr(y) :=
 eplace_with_at x y ltac:(fun x' x => set (x' := x) ).


### PR DESCRIPTION
The following files still don't work with Coq 8.12.  None of them are
imported anywhere:
File "coqutil/src/coqutil/Tactics/Records.v", line 70, characters 31-33:
Error: Syntax error: [tactic:tac2expr level 6] expected after '=>' (in [branch]).

File "coqutil/src/coqutil/Word/ZifyLittleEndian.v", line 19, characters 0-30:
Error: There is no qualid-valued table with this name: "Zify InjTyp".

File "coqutil/src/coqutil/Tactics/SafeSimpl.v", line 67, characters 11-13:
Error: Syntax error: [tactic:tac2expr] expected after ':=' (in [let_clause]).

File "coqutil/src/coqutil/Tactics/ParamRecords.v", line 53, characters 8-10:
Error: Syntax error: [tactic:tac2expr level 6] expected after 'in' (in [tactic:tac2expr]).