### PR TITLE
Partial compatibility with Coq 8.11

### DIFF
--- a/src/coqutil/Datatypes/HList.v
+++ b/src/coqutil/Datatypes/HList.v
@@ -114,14 +114,14 @@ Module tuple.
 
     Lemma to_list_of_list (xs : list A) :
       to_list (of_list xs) = xs.
-    Proof. induction xs; cbn; congruence. Qed.
+    Proof using Type. induction xs; cbn; congruence. Qed.
 
     Lemma length_to_list {n} xs : length (@to_list n xs) = n.
-    Proof. revert xs; induction n; cbn; eauto. Qed.
+    Proof using Type. revert xs; induction n; cbn; eauto. Qed.
 
     Lemma to_list_eq_rect a b xs pf
       : to_list (eq_rect a _ xs b pf) = to_list xs.
-    Proof. destruct pf. cbn. trivial. Qed.
+    Proof using Type. destruct pf. cbn. trivial. Qed.
 
     Section WithF.
       Context {B: Type}.

--- a/src/coqutil/Datatypes/List.v
+++ b/src/coqutil/Datatypes/List.v
@@ -947,7 +947,7 @@ Qed.
 Section WithZ.
   Import Coq.ZArith.BinInt.
   Local Open Scope Z_scope.
-  Lemma splitZ_spec [A] (xsys : list A) i (H : 0 <= i < Z.of_nat (length xsys)) :
+  Lemma splitZ_spec {A} (xsys : list A) i (H : 0 <= i < Z.of_nat (length xsys)) :
     let xs := firstn (Z.to_nat i) xsys in
     let ys := skipn (Z.to_nat i) xsys in
     xsys = xs ++ ys /\
@@ -959,7 +959,7 @@ Section WithZ.
     rewrite length_firstn_inbounds, length_skipn; blia.
   Qed.
 
-  Lemma splitZ_spec_n [A] (xsys : list A) i n
+  Lemma splitZ_spec_n {A} (xsys : list A) i n
     (Hn : Z.of_nat (length xsys) = n) (H : 0 <= i < n) :
     let xs := firstn (Z.to_nat i) xsys in
     let ys := skipn (Z.to_nat i) xsys in

--- a/src/coqutil/Datatypes/List.v
+++ b/src/coqutil/Datatypes/List.v
@@ -30,7 +30,7 @@ Section WithA.
 
   Lemma removeb_not_In{aeqb : A -> A -> bool}{aeqb_dec: EqDecider aeqb}:
     forall (l : list A) (a: A), ~ In a l -> removeb aeqb a l = l.
-  Proof.
+  Proof using Type.
     induction l; intros; simpl; try reflexivity.
     destr (aeqb a0 a); simpl in *; subst.
     + exfalso. auto.
@@ -39,14 +39,14 @@ Section WithA.
 
   Lemma In_removeb_In{aeqb : A -> A -> bool}{aeqb_dec: EqDecider aeqb}:
     forall (a1 a2: A) (l: list A), In a1 (removeb aeqb a2 l) -> In a1 l.
-  Proof.
+  Proof using Type.
     induction l; intros; simpl in *; try contradiction.
     destr (aeqb a2 a); simpl in *; intuition idtac.
   Qed.
 
   Lemma In_removeb_diff{aeqb : A -> A -> bool}{aeqb_dec: EqDecider aeqb}:
     forall (a1 a2: A) (l: list A), a1 <> a2 -> In a1 l -> In a1 (removeb aeqb a2 l).
-  Proof.
+  Proof using Type.
     induction l; intros; simpl in *; try contradiction.
     destr (aeqb a2 a); simpl in *; subst; intuition congruence.
   Qed.
@@ -55,7 +55,7 @@ Section WithA.
     forall (a: A) (l: list A),
       NoDup l ->
       NoDup (removeb aeqb a l).
-  Proof.
+  Proof using Type.
     induction l; intros; simpl in *; try assumption.
     destr (aeqb a a0); simpl in *; inversion H; auto.
     constructor; auto. intro C. apply H2. eapply In_removeb_In. eassumption.
@@ -66,7 +66,7 @@ Section WithA.
       In a s ->
       NoDup s ->
       Datatypes.length (removeb aeqb a s) = pred (Datatypes.length s).
-  Proof.
+  Proof using Type.
     induction s; intros.
     - simpl in H. contradiction.
     - simpl in *. inversion H0. subst. destr (aeqb a0 a).
@@ -80,7 +80,7 @@ Section WithA.
 
   Lemma option_all_None l : option_all l = None ->
     exists i, nth_error l i = Some None.
-  Proof.
+  Proof using Type.
     induction l; cbn; intuition try congruence.
     case a in *; cycle 1.
     { exists O; cbn; trivial. }
@@ -91,7 +91,7 @@ Section WithA.
   Lemma length_option_all: forall {l1: list (option A)} {l2: list A},
     option_all l1 = Some l2 ->
     length l2 = length l1.
-  Proof.
+  Proof using Type.
     induction l1; cbn; intros.
     { inversion H. trivial. }
     { case a in *; try inversion H.
@@ -104,7 +104,7 @@ Section WithA.
     (i < List.length l1)%nat ->
     exists v, nth_error l1 i = Some (Some v)
            /\ nth_error l2 i = Some v.
-  Proof.
+  Proof using Type.
     induction l1; intros.
     - simpl in *. exfalso. inversion H0.
     - simpl in *. destr a; try discriminate. destr (option_all l1); try discriminate.
@@ -118,7 +118,7 @@ Section WithA.
     option_all l1 = Some l2 ->
     In v1o l1 ->
     exists v1, v1o = Some v1 /\ In v1 l2.
-  Proof.
+  Proof using Type.
     induction l1; intros.
     - simpl in *. contradiction.
     - simpl in *. destr a; try discriminate. destr (option_all l1); try discriminate.
@@ -138,7 +138,7 @@ Section WithA.
 
   Lemma dedup_preserves_In(aeqb: A -> A -> bool){aeqb_spec: EqDecider aeqb}(l: list A) a:
     In a l <-> In a (dedup aeqb l).
-  Proof.
+  Proof using Type.
     induction l.
     - simpl. firstorder idtac.
     - simpl. split; intro H.
@@ -161,7 +161,7 @@ Section WithA.
 
   Lemma NoDup_dedup(aeqb: A -> A -> bool){aeqb_spec: EqDecider aeqb}: forall (l: list A),
       NoDup (dedup aeqb l).
-  Proof.
+  Proof using Type.
     induction l.
     - simpl. constructor.
     - simpl. destruct_one_match.
@@ -182,46 +182,46 @@ Section WithA.
       end.
 
     Lemma length_unfoldn: forall n start, length (unfoldn n start) = n.
-    Proof.
+    Proof using Type.
       induction n; intros.
       - reflexivity.
       - simpl. f_equal. apply IHn.
     Qed.
   End WithStep.
 
-  Lemma length_nil : length (@nil A) = 0. Proof. reflexivity. Qed.
+  Lemma length_nil : length (@nil A) = 0. Proof using Type. reflexivity. Qed.
   Lemma length_cons x xs : length (@cons A x xs) = S (length xs).
-  Proof. exact eq_refl. Qed.
+  Proof using Type. exact eq_refl. Qed.
 
   Lemma tl_skipn n (xs : list A) : tl (skipn n xs) = skipn (S n) xs.
-  Proof. revert xs; induction n, xs; auto; []; eapply IHn. Qed.
+  Proof using Type. revert xs; induction n, xs; auto; []; eapply IHn. Qed.
   Lemma tl_is_skipn1 (xs : list A) : tl xs = skipn 1 xs.
-  Proof. destruct xs; reflexivity. Qed.
+  Proof using Type. destruct xs; reflexivity. Qed.
   Lemma skipn_all_exact (xs : list A) : skipn (length xs) xs = nil.
-  Proof. induction xs; eauto. Qed.
+  Proof using Type. induction xs; eauto. Qed.
   Lemma skipn_0_l (xs : list A) : skipn 0 xs = xs.
-  Proof. exact eq_refl. Qed.
+  Proof using Type. exact eq_refl. Qed.
   Lemma skipn_nil_r n : @skipn A n nil = nil.
-  Proof. induction n; auto. Qed.
+  Proof using Type. induction n; auto. Qed.
   Lemma skipn_all n (xs : list A) (H : le (length xs) n) : skipn n xs = nil.
-  Proof.
+  Proof using Type.
     revert dependent xs; induction n, xs; cbn; auto; try blia; [].
     intros; rewrite IHn; trivial; blia.
   Qed.
 
   Lemma length_firstn_inbounds n (xs : list A) (H : le n (length xs))
     : length (firstn n xs) = n.
-  Proof.
+  Proof using Type.
     rewrite firstn_length, PeanoNat.Nat.min_comm.
     destruct (Min.min_spec (length xs) n); blia.
   Qed.
   Lemma length_tl_inbounds (xs : list A) : length (tl xs) = (length xs - 1)%nat.
-  Proof.
+  Proof using Type.
     destruct xs; cbn [length tl]; blia.
   Qed.
   Lemma length_skipn n (xs : list A) :
     length (skipn n xs) = (length xs - n)%nat.
-  Proof.
+  Proof using Type.
     pose proof firstn_skipn n xs as HH; eapply (f_equal (@length _)) in HH; rewrite <-HH.
     destruct (Compare_dec.le_lt_dec n (length xs)).
     { rewrite app_length, length_firstn_inbounds; blia. }
@@ -229,10 +229,10 @@ Section WithA.
   Qed.
 
   Lemma skipn_nil n: skipn n (@nil A) = nil.
-  Proof. destruct n; reflexivity. Qed.
+  Proof using Type. destruct n; reflexivity. Qed.
 
   Lemma skipn_app n (xs ys : list A) : skipn n (xs ++ ys) = skipn n xs ++ skipn (n - length xs) ys.
-  Proof.
+  Proof using Type.
     revert n ys.
     induction xs; intros.
     - simpl. rewrite skipn_nil. simpl. rewrite PeanoNat.Nat.sub_0_r. reflexivity.
@@ -242,7 +242,7 @@ Section WithA.
   Qed.
 
   Lemma skipn_skipn n m (xs : list A) : skipn n (skipn m xs) = skipn (n + m) xs.
-  Proof.
+  Proof using Type.
     revert m xs.
     induction n; intros.
     - simpl. reflexivity.
@@ -266,14 +266,14 @@ Section WithA.
   Qed.
 
   Lemma nth_error_nil_Some: forall i (a: A), nth_error nil i = Some a -> False.
-  Proof.
+  Proof using Type.
     intros. destruct i; simpl in *; discriminate.
   Qed.
 
   Lemma nth_error_single_Some: forall (a1 a2: A) i,
       nth_error (a1 :: nil) i = Some a2 ->
       i = O /\ a1 = a2.
-  Proof.
+  Proof using Type.
     intros. destruct i; inversion H; auto. simpl in *.
     exfalso. eapply nth_error_nil_Some. eassumption.
   Qed.
@@ -281,7 +281,7 @@ Section WithA.
   Lemma nth_error_cons_Some: forall (a1 a2: A) (l: list A) i,
       nth_error (a1 :: l) i = Some a2 ->
       i = O /\ a1 = a2 \/ exists j, i = S j /\ nth_error l j = Some a2.
-  Proof.
+  Proof using Type.
     intros. destruct i; simpl in *.
     - inversion H. auto.
     - eauto.
@@ -290,7 +290,7 @@ Section WithA.
   Lemma nth_error_app_Some: forall (a: A) (l1 l2: list A) i,
       nth_error (l1 ++ l2) i = Some a ->
       nth_error l1 i = Some a \/ nth_error l2 (i - length l1) = Some a.
-  Proof.
+  Proof using Type.
     intros.
     destr (Nat.ltb i (length l1)).
     - left. rewrite nth_error_app1 in H; assumption.
@@ -300,7 +300,7 @@ Section WithA.
   Lemma nth_error_map_Some {B} (f : A -> B) (l : list A) i y
     (H : nth_error (map f l) i = Some y)
     : exists x, nth_error l i = Some x /\ f x = y.
-  Proof.
+  Proof using Type.
     pose proof map_nth_error f i l as Hi.
     case (nth_error l i) eqn:Heqo in Hi.
     { specialize (Hi _ eq_refl). eexists a; split; congruence. }
@@ -314,7 +314,7 @@ Section WithA.
   Lemma nth_error_ext (xs ys : list A)
     (H : forall i, nth_error xs i = nth_error ys i)
     : xs = ys.
-  Proof.
+  Proof using Type.
     revert dependent ys; induction xs; intros;
       pose proof H O as HO;
       destruct ys; cbn in HO; inversion HO; trivial.
@@ -325,7 +325,7 @@ Section WithA.
     (Hl : length xs = length ys)
     (H : forall i, i < length xs -> nth_error xs i = nth_error ys i)
     : xs = ys.
-  Proof.
+  Proof using Type.
     eapply nth_error_ext; intros i.
     case (Compare_dec.le_lt_dec (length xs) i)as[|Hi]; eauto.
     pose proof proj2 (nth_error_None xs i) ltac:(blia).
@@ -336,17 +336,17 @@ Section WithA.
   Definition endswith (xs : list A) (suffix : list A) :=
     exists prefix, xs = prefix ++ suffix.
   Lemma endswith_refl (xs : list A) : endswith xs xs.
-  Proof. exists nil; trivial. Qed.
+  Proof using Type. exists nil; trivial. Qed.
   Lemma endswith_cons_l (x : A) xs ys :
     endswith ys xs -> endswith (cons x ys) xs.
-  Proof. inversion 1; subst. eexists (cons x _). exact eq_refl. Qed.
+  Proof using Type. inversion 1; subst. eexists (cons x _). exact eq_refl. Qed.
 
   Lemma fold_right_change_order{R: Type}(f: A -> R -> R)
         (f_comm: forall a1 a2 r, f a1 (f a2 r) = f a2 (f a1 r)):
     forall l1 l2: list A,
       Permutation l1 l2 ->
       forall r0, fold_right f r0 l1 = fold_right f r0 l2.
-  Proof.
+  Proof using Type.
     induction 1; intros.
     - reflexivity.
     - simpl. f_equal. auto.
@@ -356,11 +356,11 @@ Section WithA.
 
   Lemma hd_map {B} (f : A -> B) x l :
     hd (f x) (map f l) = f (hd x l).
-  Proof. destruct l; reflexivity. Qed.
+  Proof using Type. destruct l; reflexivity. Qed.
 
   Lemma hd_skipn_nth_default (d:A) l i :
     nth_default d l i = hd d (skipn i l).
-  Proof.
+  Proof using Type.
     rewrite nth_default_eq.
     revert i; induction l; destruct i; try reflexivity.
     rewrite skipn_cons. eauto.
@@ -368,21 +368,21 @@ Section WithA.
 
   Lemma firstn_length_firstn n (l : list A) :
     firstn (length (firstn n l)) l = firstn n l.
-  Proof.
+  Proof using Type.
     revert l; induction n; destruct l;
       cbn [firstn length]; rewrite ?IHn; reflexivity.
   Qed.
 
   Lemma skipn_length_firstn n (l : list A) :
     skipn (length (firstn n l)) l = skipn n l.
-  Proof.
+  Proof using Type.
     revert l; induction n; destruct l;
       cbn [skipn firstn length]; rewrite ?IHn; reflexivity.
   Qed.
 
   Lemma firstn_map{B: Type}: forall (f: A -> B) (n: nat) (l: list A),
       firstn n (map f l) = map f (firstn n l).
-  Proof.
+  Proof using Type.
     induction n; intros.
     - reflexivity.
     - simpl. destruct l; simpl; congruence.
@@ -390,7 +390,7 @@ Section WithA.
 
   Lemma firstn_seq: forall (n from len: nat),
       firstn n (seq from len) = seq from (min n len).
-  Proof.
+  Proof using Type.
     induction n; intros.
     - reflexivity.
     - simpl. destruct len; simpl; f_equal; auto.
@@ -400,7 +400,7 @@ Section WithA.
     NoDup (l1 ++ l2) <-> (NoDup l1 /\ NoDup l2
                           /\ (forall x, In x l1 -> ~ In x l2)
                           /\ (forall x, In x l2 -> ~ In x l1)).
-  Proof.
+  Proof using Type.
     revert l2; induction l1;
       repeat match goal with
              | _ => progress (intros; subst)
@@ -435,7 +435,7 @@ Section WithA.
   Lemma Forall2_impl_strong {B} (R1 R2 : A -> B -> Prop) xs ys :
     (forall x y, R1 x y -> In x xs -> In y ys -> R2 x y) ->
     Forall2 R1 xs ys -> Forall2 R2 xs ys.
-  Proof.
+  Proof using Type.
     revert ys; induction xs; destruct ys; intros;
       match goal with H : Forall2 _ _ _ |- _ =>
                       inversion H; subst; clear H end;
@@ -447,7 +447,7 @@ Section WithA.
     length xs1 = length ys1 ->
     Forall2 R (xs1 ++ xs2) (ys1 ++ ys2) ->
     Forall2 R xs1 ys1 /\ Forall2 R xs2 ys2.
-  Proof.
+  Proof using Type.
     revert xs2 ys1 ys2; induction xs1;
       destruct ys1; cbn [length]; intros; try congruence.
     all:repeat match goal with
@@ -466,7 +466,7 @@ Section WithA.
 
   Lemma NoDup_combine_l {B} xs ys :
     NoDup xs -> NoDup (@combine A B xs ys).
-  Proof.
+  Proof using Type.
     revert ys; induction xs; destruct ys; inversion 1;
       intros; subst; cbn [combine]; constructor; auto; [ ].
     let H := fresh in intro H; apply in_combine_l in H.
@@ -475,7 +475,7 @@ Section WithA.
 
   Lemma nth_default_preserves_properties (P : A -> Prop) l n d :
     (forall x, In x l -> P x) -> P d -> P (nth_default d l n).
-  Proof.
+  Proof using Type.
     rewrite nth_default_eq.
     destruct (nth_in_or_default n l d); auto.
     congruence.
@@ -484,7 +484,7 @@ Section WithA.
   Lemma Forall_nth_default (R : A -> Prop) d xs i :
     Forall R xs -> R d ->
     R (nth_default d xs i).
-  Proof.
+  Proof using Type.
     apply nth_default_preserves_properties; intros;
       try match goal with H : _ |- _ =>
                           rewrite Forall_forall in H end;
@@ -494,7 +494,7 @@ Section WithA.
   Lemma Forall_snoc (R : A -> Prop) xs x :
     Forall R xs -> R x ->
     Forall R (xs ++ [x]).
-  Proof.
+  Proof using Type.
     induction xs; intros;
       rewrite ?app_nil_l, <-?app_comm_cons;
       try match goal with H : Forall _ (_ :: _) |- _ =>
@@ -505,7 +505,7 @@ Section WithA.
   Lemma forallb_to_Forall(p: A -> bool)(P: A -> Prop):
     (forall x, p x = true -> P x) ->
     forall l, forallb p l = true -> Forall P l.
-  Proof.
+  Proof using Type.
     induction l; simpl; intros. 1: constructor.
     apply Bool.andb_true_iff in H0. destruct H0. constructor; eauto.
   Qed.
@@ -513,7 +513,7 @@ Section WithA.
   Lemma Forall_to_forallb(p: A -> bool)(P: A -> Prop):
     (forall x, P x -> p x = true) ->
     forall l, Forall P l -> forallb p l = true.
-  Proof.
+  Proof using Type.
     induction 2; simpl; intros. 1: constructor.
     apply Bool.andb_true_iff. eauto.
   Qed.
@@ -523,7 +523,7 @@ Section WithA.
 
   Lemma list_forallb_eqb_refl (aeqb : A -> A -> bool) {aeqb_spec:EqDecider aeqb} ls :
     forallb (fun xy => aeqb (fst xy) (snd xy)) (combine ls ls) = true.
-  Proof.
+  Proof using Type.
     induction ls as [|x ?]; [ reflexivity | ].
     cbn [combine fst snd forallb]. rewrite IHls.
     destr (aeqb x x); subst; congruence || reflexivity.
@@ -532,7 +532,7 @@ Section WithA.
   Lemma length_eq_forallb_eqb_false (aeqb : A -> A -> bool) {aeqb_spec:EqDecider aeqb} x y :
     length x = length y -> x <> y ->
     forallb (fun xy => aeqb (fst xy) (snd xy)) (combine x y) = false.
-  Proof.
+  Proof using Type.
     revert y.
     induction x as [|x0 x]; destruct y as [|y0 y];
       cbn [length]; [ congruence .. | ].
@@ -543,7 +543,7 @@ Section WithA.
 
   Lemma list_eqb_spec (aeqb : A -> A -> bool) {aeqb_spec:EqDecider aeqb}
     : EqDecider (list_eqb aeqb).
-  Proof.
+  Proof using Type.
     cbv [list_eqb].
     induction x as [|x0 x]; destruct y as [|y0 y];
       cbn [length combine forallb Nat.eqb andb fst snd];

--- a/src/coqutil/Datatypes/ListSet.v
+++ b/src/coqutil/Datatypes/ListSet.v
@@ -30,7 +30,7 @@ Section ListSetProofs.
 
   Lemma length_list_union_nil_r: forall (l: list E),
       length (list_union eeq l []) <= length l.
-  Proof.
+  Proof using Type.
     induction l.
     - simpl. reflexivity.
     - simpl. destruct_one_match; simpl; blia.
@@ -40,7 +40,7 @@ Section ListSetProofs.
       find (eeq a) (list_union eeq l1 (a0 :: l2)) = None ->
       find (eeq a) (list_union eeq l1 l2) = Some e ->
       False.
-  Proof.
+  Proof using eeq_spec.
     induction l1; intros.
     - simpl in *. destr (eeq a a0); congruence.
     - simpl in *.
@@ -60,7 +60,7 @@ Section ListSetProofs.
       find (eeq a) (list_union eeq l1 (a0 :: l2)) = Some e ->
       find (eeq a) (list_union eeq l1 l2) = None ->
       a = a0 /\ a = e.
-  Proof.
+  Proof using eeq_spec.
     induction l1; intros.
     - simpl in *. destruct_one_match_hyp.
       + split; congruence.
@@ -83,7 +83,7 @@ Section ListSetProofs.
 
   Lemma length_list_union_cons_r: forall (l1 l2: list E) (a: E),
       length (list_union eeq l1 (a :: l2)) <= S (length (list_union eeq l1 l2)).
-  Proof.
+  Proof using eeq_spec.
     induction l1; intros.
     - simpl. reflexivity.
     - simpl. destr (find (eeq a) (list_union eeq l1 l2)).
@@ -100,7 +100,7 @@ Section ListSetProofs.
 
   Lemma length_list_union: forall (l1 l2: list E),
       (length (list_union eeq l1 l2) <= length l1 + length l2)%nat.
-  Proof.
+  Proof using eeq_spec.
     induction l2.
     - pose proof (length_list_union_nil_r l1). blia.
     - pose proof (length_list_union_cons_r l1 l2 a). simpl. blia.
@@ -108,14 +108,14 @@ Section ListSetProofs.
 
   Lemma list_union_empty_l: forall l,
       list_union eeq nil l = l.
-  Proof.
+  Proof using Type.
     intros. reflexivity.
   Qed.
 
   Lemma list_union_empty_r: forall l,
       NoDup l ->
       list_union eeq l nil = l.
-  Proof.
+  Proof using eeq_spec.
     induction l; intros.
     - reflexivity.
     - simpl. inversion H. subst.
@@ -129,14 +129,14 @@ Section ListSetProofs.
       Forall P l1 ->
       Forall P l2 ->
       Forall P (list_union eeq l1 l2).
-  Proof.
+  Proof using Type.
     induction l1; intros; simpl; [assumption|].
     inversion H. subst. clear H. destruct_one_match; eauto.
   Qed.
 
   Lemma of_list_removeb: forall x A,
       of_list (removeb eeq x A) = diff (of_list A) (singleton_set x).
-  Proof.
+  Proof using Type.
     unfold of_list, diff, singleton_set, elem_of. intros.
     extensionality e. apply propositional_extensionality. split.
     - induction A; intros.
@@ -153,7 +153,7 @@ Section ListSetProofs.
 
   Lemma In_list_union_spec: forall (l1 l2 : list E) (x: E),
       In x (list_union eeq l1 l2) <-> In x l1 \/ In x l2.
-  Proof.
+  Proof using eeq_spec.
     induction l1; intros.
     - simpl. split; intuition idtac.
     - simpl. destruct_one_match; simpl; split; intros.
@@ -169,7 +169,7 @@ Section ListSetProofs.
 
   Lemma of_list_list_union: forall (l1 l2: list E),
       of_list (list_union eeq l1 l2) = union (of_list l1) (of_list l2).
-  Proof.
+  Proof using eeq_spec.
     intros.
     extensionality e. apply propositional_extensionality.
     unfold of_list, union, elem_of.
@@ -179,7 +179,7 @@ Section ListSetProofs.
   (* Note: l1 can have duplicates, because it's going to be inserted into l2 one by one *)
   Lemma list_union_preserves_NoDup: forall (l1 l2: list E),
       NoDup l2 -> NoDup (list_union eeq l1 l2).
-  Proof.
+  Proof using eeq_spec.
     induction l1; intros.
     - simpl. assumption.
     - simpl.
@@ -194,15 +194,15 @@ Section ListSetProofs.
   Lemma In_list_union_l: forall (l1 l2: list E) (x: E),
       In x l1 ->
       In x (list_union eeq l1 l2).
-  Proof. intros. eapply In_list_union_spec. left. assumption. Qed.
+  Proof using eeq_spec. intros. eapply In_list_union_spec. left. assumption. Qed.
 
   Lemma In_list_union_r: forall (l1 l2: list E) (x: E),
       In x l2 ->
       In x (list_union eeq l1 l2).
-  Proof. intros. eapply In_list_union_spec. right. assumption. Qed.
+  Proof using eeq_spec. intros. eapply In_list_union_spec. right. assumption. Qed.
 
   Lemma In_list_union_invert: forall (l1 l2 : list E) (x: E),
       In x (list_union eeq l1 l2) -> In x l1 \/ In x l2.
-  Proof. intros. eapply In_list_union_spec. assumption. Qed.
+  Proof using eeq_spec. intros. eapply In_list_union_spec. assumption. Qed.
 
 End ListSetProofs.

--- a/src/coqutil/Datatypes/PropSet.v
+++ b/src/coqutil/Datatypes/PropSet.v
@@ -59,13 +59,13 @@ Section PropSetLemmas.
 
   Lemma of_list_cons: forall (e: E) (l: list E),
       sameset (of_list (e :: l)) (add (of_list l) e).
-  Proof.
+  Proof using Type.
     intros. repeat autounfold with unf_derived_set_defs. simpl. auto.
   Qed.
 
   Lemma of_list_app: forall (l1 l2: list E),
       sameset (of_list (l1 ++ l2)) (union (of_list l1) (of_list l2)).
-  Proof.
+  Proof using Type.
     induction l1; repeat autounfold with unf_basic_set_defs unf_derived_set_defs in *;
       intros; simpl; [intuition idtac|].
     setoid_rewrite in_app_iff in IHl1.
@@ -76,109 +76,109 @@ Section PropSetLemmas.
   Lemma disjoint_diff_l: forall (A B C: set E),
       disjoint A C ->
       disjoint (diff A B) C.
-  Proof.
+  Proof using Type.
     intros. unfold set, disjoint, diff in *. firstorder idtac.
   Qed.
 
   Lemma disjoint_diff_r: forall (A B C: set E),
       disjoint C A ->
       disjoint C (diff A B).
-  Proof.
+  Proof using Type.
     intros. unfold set, disjoint, diff in *. firstorder idtac.
   Qed.
 
   Lemma subset_empty_l (s : set E) :
     subset empty_set s.
-  Proof. firstorder idtac. Qed.
+  Proof using Type. firstorder idtac. Qed.
 
   Lemma union_empty_l (s : set E) :
     sameset (union empty_set s) s.
-  Proof. firstorder idtac. Qed.
+  Proof using Type. firstorder idtac. Qed.
 
   Lemma union_empty_r (s : set E) :
     sameset (union s empty_set) s.
-  Proof. firstorder idtac. Qed.
+  Proof using Type. firstorder idtac. Qed.
 
   Lemma disjoint_empty_l (s : set E) :
     disjoint empty_set s.
-  Proof. firstorder idtac. Qed.
+  Proof using Type. firstorder idtac. Qed.
 
   Lemma disjoint_empty_r (s : set E) :
     disjoint s empty_set.
-  Proof. firstorder idtac. Qed.
+  Proof using Type. firstorder idtac. Qed.
 
   Lemma union_comm (s1 s2 : set E) :
     sameset (union s1 s2) (union s2 s1).
-  Proof. firstorder idtac. Qed.
+  Proof using Type. firstorder idtac. Qed.
 
   Lemma union_assoc (s1 s2 s3 : set E) :
     sameset (union s1 (union s2 s3)) (union (union s1 s2) s3).
-  Proof. firstorder idtac. Qed.
+  Proof using Type. firstorder idtac. Qed.
 
   Lemma of_list_nil : sameset (@of_list E []) empty_set.
-  Proof. firstorder idtac. Qed.
+  Proof using Type. firstorder idtac. Qed.
 
   Lemma of_list_singleton x: sameset (@of_list E [x]) (singleton_set x).
-  Proof. firstorder idtac. Qed.
+  Proof using Type. firstorder idtac. Qed.
 
   Lemma sameset_iff (s1 s2 : set E) :
     sameset s1 s2 <-> (forall e, s1 e <-> s2 e).
-  Proof. firstorder idtac. Qed.
+  Proof using Type. firstorder idtac. Qed.
 
   Lemma add_union_singleton (x : E) s :
     add s x = union (singleton_set x) s.
-  Proof. firstorder idtac. Qed.
+  Proof using Type. firstorder idtac. Qed.
 
   Lemma not_union_iff (s1 s2 : set E) x :
     ~ union s1 s2 x <-> ~ s1 x /\ ~ s2 x.
-  Proof. firstorder idtac. Qed.
+  Proof using Type. firstorder idtac. Qed.
 
   Lemma disjoint_cons (s : set E) x l :
     disjoint s (of_list (x :: l)) ->
     disjoint s (of_list l) /\ disjoint s (singleton_set x).
-  Proof. firstorder idtac. Qed.
+  Proof using Type. firstorder idtac. Qed.
 
   Lemma disjoint_sameset (s1 s2 s3 : set E) :
     sameset s3 s1 ->
     disjoint s1 s2 ->
     disjoint s3 s2.
-  Proof. firstorder idtac. Qed.
+  Proof using Type. firstorder idtac. Qed.
 
   Lemma disjoint_union_l_iff (s1 s2 s3 : set E) :
     disjoint (union s1 s2) s3 <-> disjoint s1 s3 /\ disjoint s2 s3.
-  Proof. firstorder idtac. Qed.
+  Proof using Type. firstorder idtac. Qed.
 
   Lemma disjoint_union_r_iff (s1 s2 s3 : set E) :
     disjoint s1 (union s2 s3) <-> disjoint s1 s2 /\ disjoint s1 s3.
-  Proof. firstorder idtac. Qed.
+  Proof using Type. firstorder idtac. Qed.
 
   Lemma subset_union_l (s1 s2 s3 : set E) :
     subset s1 s3 ->
     subset s2 s3 ->
     subset (union s1 s2) s3.
-  Proof. firstorder idtac. Qed.
+  Proof using Type. firstorder idtac. Qed.
 
   Lemma subset_union_rl (s1 s2 s3 : set E) :
     subset s1 s2 ->
     subset s1 (union s2 s3).
-  Proof. firstorder idtac. Qed.
+  Proof using Type. firstorder idtac. Qed.
 
   Lemma subset_union_rr (s1 s2 s3 : set E) :
     subset s1 s3 ->
     subset s1 (union s2 s3).
-  Proof. firstorder idtac. Qed.
+  Proof using Type. firstorder idtac. Qed.
 
   Lemma subset_disjoint_r (s1 s2 s3 : set E) :
     subset s2 s3 ->
     disjoint s1 s3 ->
     disjoint s1 s2.
-  Proof. firstorder idtac. Qed.
+  Proof using Type. firstorder idtac. Qed.
 
   Lemma subset_disjoint_l (s1 s2 s3 : set E) :
     subset s1 s3 ->
     disjoint s3 s2 ->
     disjoint s1 s2.
-  Proof. firstorder idtac. Qed.
+  Proof using Type. firstorder idtac. Qed.
 
   Global Instance Proper_union :
     Proper (sameset ==> sameset ==> sameset) (@union E).
@@ -234,7 +234,7 @@ Section PropSetLemmas.
     Lemma disjoint_singleton_r_iff (x : E) (s : set E) :
       ~ s x <->
       disjoint s (singleton_set x).
-    Proof.
+    Proof using eq_dec.
       intros. split; [|firstorder idtac].
       intros. intro y.
       destruct (eq_dec x y);
@@ -244,7 +244,7 @@ Section PropSetLemmas.
     Lemma disjoint_singleton_singleton (x y : E) :
       y <> x ->
       disjoint (singleton_set x) (singleton_set y).
-    Proof.
+    Proof using eq_dec.
       intros.
       apply disjoint_singleton_r_iff;
         firstorder congruence.
@@ -253,14 +253,14 @@ Section PropSetLemmas.
     Lemma disjoint_not_in x (l : list E) :
       ~ In x l ->
       disjoint (singleton_set x) (of_list l).
-    Proof.
+    Proof using eq_dec.
       intros. symmetry. apply disjoint_singleton_r_iff; eauto.
     Qed.
 
     Lemma NoDup_disjoint (l1 l2 : list E) :
       NoDup (l1 ++ l2) ->
       disjoint (of_list l1) (of_list l2).
-    Proof.
+    Proof using eq_dec.
       revert l2; induction l1; intros *;
         rewrite ?app_nil_l, <-?app_comm_cons;
         [ solve [firstorder idtac] | ].
@@ -276,7 +276,7 @@ Section PropSetLemmas.
       NoDup l2 ->
       disjoint (of_list l1) (of_list l2) ->
       NoDup (l1 ++ l2).
-    Proof.
+    Proof using eq_dec.
       revert l2; induction l1; intros *;
         rewrite ?app_nil_l, <-?app_comm_cons;
         [ solve [firstorder idtac] | ].

--- a/src/coqutil/Map/Funext.v
+++ b/src/coqutil/Map/Funext.v
@@ -37,7 +37,7 @@ Section SortedList.
   |}.
 
   Global Instance map_ok : map.ok map.
-  Proof.
+  Proof using magic_fold_is_magic magic_fold_respects_relations ok.
     split; cbv [map.rep map.empty map.get map.put map.remove map.fold map]; intros;
       repeat match goal with
       | |- context[eqb ?a ?b] => destruct (eqb_ok a b)

--- a/src/coqutil/Map/MapKeys.v
+++ b/src/coqutil/Map/MapKeys.v
@@ -13,7 +13,7 @@ Module map.
     Lemma get_map_keys_invertible (f : key -> key') m k
       (H:forall k' v', get m k' = Some v' -> f k = f k' -> get m k = get m k')
       : get (map_keys f m) (f k) = get m k.
-    Proof.
+    Proof using key'_eq_dec key_eq_dec ok ok'.
       revert dependent k.
       cbv [map_keys].
       refine (fold_spec (fun m r => forall k,
@@ -42,7 +42,7 @@ Module map.
     Lemma get_map_keys_always_invertible (f : key -> key')
       (H : forall k k', f k = f k' -> k = k')
       : forall m k, get (map_keys f m) (f k) = get m k.
-    Proof.
+    Proof using key'_eq_dec key_eq_dec ok ok'.
       intros. eapply get_map_keys_invertible. intros ? ? HA HB.
       rewrite (H _ _ HB); trivial.
     Qed.

--- a/src/coqutil/Map/OfFunc.v
+++ b/src/coqutil/Map/OfFunc.v
@@ -23,7 +23,7 @@ Module map.
       induction support.
       { firstorder idtac. }
       { destruct (key_eq_dec a k); intros [|]; subst;
-          pose proof Properties.map.get_update_same;
+          pose proof (Properties.map.get_update_same (ok:=ok));
           cbn; try congruence; [].
         rewrite Properties.map.get_update_diff by congruence.
         eauto. }

--- a/src/coqutil/Map/OfFunc.v
+++ b/src/coqutil/Map/OfFunc.v
@@ -18,7 +18,7 @@ Module map.
 
     Lemma get_of_func_In k support (Hs : List.In k support)
       : get (of_func support) k = f k.
-    Proof.
+    Proof using key_eq_dec ok.
       revert dependent support.
       induction support.
       { firstorder idtac. }
@@ -31,7 +31,7 @@ Module map.
 
     Lemma get_of_func_Some_In k support v (H:get (of_func support) k = Some v)
       : List.In k support.
-    Proof.
+    Proof using key_eq_dec ok.
       revert dependent support.
       induction support.
       { cbn. rewrite get_empty. discriminate. }
@@ -41,13 +41,13 @@ Module map.
 
     Lemma get_of_func_notIn k support (Hs : not (List.In k support))
       : get (of_func support) k = None.
-    Proof.
+    Proof using key_eq_dec ok.
       case (get (of_func support) k) eqn:H; trivial.
       eapply get_of_func_Some_In in H; intuition.
     Qed.
 
     Lemma get_of_func_None k s (H:f k = None) : get (of_func s) k = None.
-    Proof.
+    Proof using key_eq_dec ok.
       induction s.
       { firstorder idtac. }
       { destruct (key_eq_dec a k); subst.
@@ -60,12 +60,12 @@ Module map.
       support (Hs : forall k v, f k = Some v -> List.In k support)
       k v (Hk : f k = Some v)
       : get (of_func support) k = f k.
-    Proof. eauto using get_of_func_In. Qed.
+    Proof using key_eq_dec ok. eauto using get_of_func_In. Qed.
 
     Lemma get_of_func_Some_supported
       support (Hs : forall k v, f k = Some v -> List.In k support) k
       : get (of_func support) k = f k.
-    Proof.
+    Proof using key_eq_dec ok.
       case (f k) eqn:H.
       { pose proof get_of_func_Some_supported_In _ Hs _ _ H; congruence. }
       { eauto using get_of_func_None. }
@@ -73,7 +73,7 @@ Module map.
 
     Lemma get_of_func_type_supported k support (Hs : forall k, List.In k support)
       : get (of_func support) k = f k.
-    Proof. eauto using get_of_func_In. Qed.
+    Proof using key_eq_dec ok. eauto using get_of_func_In. Qed.
   End OfFunc.
 
   Import Coq.Lists.List coqutil.Datatypes.List Interface.map.
@@ -85,7 +85,7 @@ Module map.
       map_keys (Nat.add a) (of_list_nat xs).
 
     Lemma get_of_list_nat xs i : get (of_list_nat xs) i = nth_error xs i.
-    Proof.
+    Proof using ok.
       pose proof Nat.eqb_spec.
       cbv [of_list_nat].
       erewrite get_of_func_Some_supported; trivial; intros.
@@ -94,7 +94,7 @@ Module map.
     Qed.
 
     Lemma get_of_list_nat_at a xs i : get (of_list_nat_at a xs) (a+i) = nth_error xs i.
-    Proof.
+    Proof using ok.
       cbv [of_list_nat_at].
       rewrite get_map_keys_always_invertible, get_of_list_nat; trivial; intros; blia.
     Qed.
@@ -109,7 +109,7 @@ Module map.
       map_keys (Z.add a) (of_list_Z xs).
 
     Lemma get_of_list_Z xs i : get (of_list_Z xs) i = Znth_error xs i.
-    Proof.
+    Proof using ok.
       pose proof Decidable.Z.eqb_spec.
       cbv [Znth_error of_list_Z].
       erewrite get_of_func_Some_supported; trivial; intros.
@@ -120,7 +120,7 @@ Module map.
     Qed.
 
     Lemma get_of_list_Z_at a xs i : get (of_list_Z_at a xs) i = Znth_error xs (i-a)%Z.
-    Proof.
+    Proof using ok.
       cbv [of_list_Z_at].
       replace i with (a+(i-a)) by blia.
       rewrite get_map_keys_always_invertible, get_of_list_Z by (intros; blia).
@@ -130,7 +130,7 @@ Module map.
     Lemma get_of_list_Z_at_app a xs ys :
       of_list_Z_at a (xs ++ ys) =
       putmany (of_list_Z_at a xs) (of_list_Z_at (a+Z.of_nat (length xs)) ys).
-    Proof.
+    Proof using ok.
       apply map_ext; intros k.
       rewrite Properties.map.get_putmany_dec, 3get_of_list_Z_at.
       cbv [Znth_error].

--- a/src/coqutil/Map/OfListWord.v
+++ b/src/coqutil/Map/OfListWord.v
@@ -20,7 +20,7 @@ Module map.
     Lemma get_of_list_word xs i : get (of_list_word xs) i
       = nth_error xs (Z.to_nat (word.unsigned i)).
     Proof using ok word_ok.
-      pose proof word.eqb_spec.
+      pose proof (word.eqb_spec (word_ok:=word_ok)).
       cbv [of_list_word].
       erewrite get_of_func_Some_supported; trivial; intros.
       pose proof word.unsigned_range k.

--- a/src/coqutil/Map/OfListWord.v
+++ b/src/coqutil/Map/OfListWord.v
@@ -19,7 +19,7 @@ Module map.
       map_keys (word.add a) (of_list_word xs).
     Lemma get_of_list_word xs i : get (of_list_word xs) i
       = nth_error xs (Z.to_nat (word.unsigned i)).
-    Proof.
+    Proof using ok word_ok.
       pose proof word.eqb_spec.
       cbv [of_list_word].
       erewrite get_of_func_Some_supported; trivial; intros.
@@ -31,7 +31,7 @@ Module map.
     Qed.
     Lemma get_of_list_word_at a xs i : get (of_list_word_at a xs) i
       = nth_error xs (Z.to_nat (word.unsigned (word.sub i a))).
-    Proof.
+    Proof using ok word_ok.
       cbv [of_list_word_at].
       replace i with (word.add a (word.sub i a)) by ring.
       rewrite get_map_keys_always_invertible, get_of_list_word.
@@ -46,7 +46,7 @@ Module map.
       get (of_list_word_at a xs) i <> None
       <->
       (0 <= word.unsigned (word.sub i a) < Z.of_nat (length xs))%Z.
-    Proof.
+    Proof using ok word_ok.
       pose proof word.unsigned_range (word.sub i a).
       rewrite get_of_list_word_at, nth_error_Some.
       rewrite Nat2Z.inj_lt, ?Znat.Z2Nat.id; intuition.
@@ -55,7 +55,7 @@ Module map.
     Lemma of_list_word_at_app a xs ys :
       of_list_word_at a (xs ++ ys) =
       putmany (of_list_word_at (word.add a (word.of_Z (Z.of_nat (length xs)))) ys) (of_list_word_at a xs).
-    Proof.
+    Proof using ok word_ok.
       eapply map_ext; intros k.
       rewrite get_of_list_word_at.
       pose proof word.unsigned_range (word.sub k a) as Hrange.
@@ -82,7 +82,7 @@ Module map.
 
     Lemma adjacent_arrays_disjoint a xs ys (H : (Z.of_nat (length xs) + Z.of_nat (length ys) <= 2^width)%Z) :
       disjoint (of_list_word_at (word.add a (word.of_Z (Z.of_nat (length xs)))) ys) (of_list_word_at a xs).
-    Proof.
+    Proof using ok word_ok.
       intros k y x Hy Hx.
       assert ((Z.of_nat (length xs) <= 2^width)%Z) by blia.
       assert ((Z.of_nat (length ys) <= 2^width)%Z) by blia.
@@ -111,20 +111,20 @@ Module map.
       lxs (Hlxs : Z.of_nat (length xs) = lxs)
       : of_list_word_at a (xs ++ ys)
       = putmany (of_list_word_at (word.add a (word.of_Z lxs)) ys) (of_list_word_at a xs).
-    Proof. subst lxs; eapply of_list_word_at_app. Qed.
+    Proof using ok word_ok. subst lxs; eapply of_list_word_at_app. Qed.
 
     Lemma adjacent_arrays_disjoint_n
       (a : word) (xs ys : list value)
       lxs (Hlxs : Z.of_nat (length xs) = lxs)
       (H : (Z.of_nat (length xs) + Z.of_nat (length ys) <= 2 ^ width)%Z)
       : disjoint (of_list_word_at (word.add a (word.of_Z lxs)) ys) (of_list_word_at a xs).
-    Proof. subst lxs. auto using adjacent_arrays_disjoint. Qed.
+    Proof using ok word_ok. subst lxs. auto using adjacent_arrays_disjoint. Qed.
 
     Lemma of_list_word_nil k : of_list_word_at k nil = empty.
-    Proof. apply Properties.map.fold_empty. Qed.
+    Proof using ok. apply Properties.map.fold_empty. Qed.
 
     Lemma of_list_word_singleton k v : of_list_word_at k (cons v nil) = put empty k v.
-    Proof.
+    Proof using ok word_ok.
       cbv [of_list_word_at of_list_word seq length List.map of_func update].
       rewrite word.unsigned_of_Z_0, Znat.Z2Nat.inj_0; cbv [MapKeys.map.map_keys nth_error].
       rewrite Properties.map.fold_singleton.

--- a/src/coqutil/Map/Properties.v
+++ b/src/coqutil/Map/Properties.v
@@ -116,8 +116,8 @@ Module map.
         destruct (putmany_spec m1 m2 k); firstorder congruence.
     Qed.
 
-    Lemma disjoint_empty_l x : disjoint empty x. intros k **; pose proof using ok get_empty k; congruence. Qed.
-    Lemma disjoint_empty_r x : disjoint x empty. intros k **; pose proof using ok get_empty k; congruence. Qed.
+    Lemma disjoint_empty_l x : disjoint empty x. Proof using ok. intros k **; pose proof get_empty k; congruence. Qed.
+    Lemma disjoint_empty_r x : disjoint x empty. Proof using ok. intros k **; pose proof get_empty k; congruence. Qed.
     Lemma disjoint_comm m1 m2 : disjoint m1 m2 <-> disjoint m2 m1.
     Proof using ok. cbv [disjoint]. firstorder idtac. Qed.
     Lemma disjoint_putmany_r x y z : disjoint x (putmany y z) <-> (disjoint x y /\ disjoint x z).

--- a/src/coqutil/Map/SortedList.v
+++ b/src/coqutil/Map/SortedList.v
@@ -60,7 +60,7 @@ Section SortedList.
   Record rep := { value : list (key * value) ; _value_ok : sorted value = true }.
 
   Lemma ltb_antisym k1 k2 (H:eqb k1 k2 = false) : ltb k1 k2 = negb (ltb k2 k1).
-  Proof.
+  Proof using ok.
     apply Bool.andb_false_iff in H.
     destruct (ltb k1 k2) eqn:H1; destruct (ltb k2 k1) eqn:H2; cbn in *; trivial.
     { pose proof ltb_trans _ _ _ H1 H2; pose proof ltb_antirefl k1; congruence. }
@@ -68,7 +68,7 @@ Section SortedList.
   Qed.
 
   Lemma sorted_put m k v : sorted m = true -> sorted (put m k v) = true.
-  Proof.
+  Proof using ok.
     revert v; revert k; induction m as [|[k0 v0] m]; trivial; []; intros k v H.
     cbn [put]; destruct (ltb k k0) eqn:?.
     { eapply Bool.andb_true_iff; split; assumption. }
@@ -83,7 +83,7 @@ Section SortedList.
   Qed.
 
   Lemma sorted_remove m k : sorted m = true -> sorted (remove m k) = true.
-  Proof.
+  Proof using ok.
     revert k; induction m as [|[k0 v0] m]; [trivial|]; []; intros k H.
     cbn [remove].
     destruct (ltb k k0) eqn:?; trivial; [].
@@ -105,12 +105,12 @@ Section SortedList.
     end.
 
   Lemma eqb_refl: forall x: key, eqb x x = true.
-  Proof.
+  Proof using ok.
     intros. unfold eqb. rewrite (@ltb_antirefl _ _ ok). reflexivity.
   Qed.
 
   Lemma eqb_true: forall k1 k2, eqb k1 k2 = true <-> k1 = k2.
-  Proof.
+  Proof using ok.
     unfold eqb. intros.
     split; intros.
     - eapply Bool.andb_true_iff in H. destruct H as [L1 L2].
@@ -124,7 +124,7 @@ Section SortedList.
   Qed.
 
   Lemma eqb_false: forall k1 k2, eqb k1 k2 = false <-> k1 <> k2.
-  Proof.
+  Proof using ok.
     intros.
     rewrite <-Bool.not_true_iff_false.
     unfold not.
@@ -133,7 +133,7 @@ Section SortedList.
   Qed.
 
   Lemma eqb_sym: forall k1 k2, eqb k1 k2 = eqb k2 k1.
-  Proof.
+  Proof using Type.
     unfold eqb. intros.
     destruct (ltb k1 k2) eqn: E12;
     destruct (ltb k2 k1) eqn: E21;
@@ -142,14 +142,14 @@ Section SortedList.
 
   Lemma lookup_cons: forall k1 k2 v l,
       lookup ((k1, v) :: l) k2 = if eqb k2 k1 then Some v else lookup l k2.
-  Proof.
+  Proof using Type.
     unfold lookup. intros. simpl. rewrite eqb_sym. destruct (eqb k1 k2); reflexivity.
   Qed.
 
   Lemma sorted_cons: forall l k v,
       sorted ((k, v) :: l) = true ->
       sorted l = true /\ lookup l k = None /\ forall k0, ltb k0 k = true -> lookup l k0 = None.
-  Proof.
+  Proof using ok.
     induction l; intros.
     - simpl. auto.
     - simpl in *. destruct a as [k' v'].
@@ -183,14 +183,14 @@ Section SortedList.
   |}.
 
   Lemma eq_value {x y : rep} : value x = value y -> x = y.
-  Proof.
+  Proof using Type.
     cbv [value]; destruct x as [x px], y as [y py].
     intro; subst y.
     apply f_equal, Eqdep_dec.UIP_dec; decide equality.
   Qed.
 
   Global Instance map_ok : map.ok map.
-  Proof.
+  Proof using Type.
     split.
     { intros [l1 ST1] [l2 ST2] F.
       apply eq_value; unfold map.get, map in *; cbn [value] in *.

--- a/src/coqutil/Map/SortedListWord.v
+++ b/src/coqutil/Map/SortedListWord.v
@@ -6,7 +6,7 @@ Section __.
   Context {width} (word : word width) {word_ok : @word.ok width word}.
   Global Instance strict_order_word
     : SortedList.parameters.strict_order (T:=word) word.ltu.
-  Proof.
+  Proof using word_ok.
     split; try setoid_rewrite word.unsigned_ltu; intros;
       repeat match goal with
              | H: context[Z.ltb ?a ?b] |- _ => destruct (Z.ltb_spec a b)

--- a/src/coqutil/Map/TestGoals.v
+++ b/src/coqutil/Map/TestGoals.v
@@ -20,7 +20,7 @@ Section TestGoals.
 
   Lemma only_differ_of_singleton_list: forall r x v,
       map.only_differ r (PropSet.of_list [x]) (map.put r x v).
-  Proof.
+  Proof using K_eq_dec mapspecs.
     Time map_solver mapspecs.
   Qed.
 
@@ -28,7 +28,7 @@ Section TestGoals.
       only_differ st2 mv2 finalS ->
       only_differ initialS mv1 st2 ->
       only_differ initialS (union mv1 mv2) finalS.
-  Proof.
+  Proof using K_eq_dec mapspecs.
     Time map_solver mapspecs.
   Qed.
 
@@ -40,7 +40,7 @@ Section TestGoals.
     forall (resVar : K) (initialH initialL : locals) (fvngs1 : K -> Prop) (v0 : V),
       extends initialL initialH ->
       undef_on initialH fvngs1 -> get (put initialL resVar v0) resVar = Some v0.
-  Proof.
+  Proof using K_eq_dec mapspecs.
     Time map_solver mapspecs.
   Qed.
 
@@ -49,7 +49,7 @@ Section TestGoals.
       extends initialL initialH ->
       undef_on initialH fvngs1 ->
       get initialH x = Some res -> get (put initialL resVar res) resVar = get initialH x.
-  Proof.
+  Proof using K_eq_dec mapspecs.
     Time map_solver mapspecs.
   Qed.
 
@@ -63,7 +63,7 @@ Section TestGoals.
       v0 \in mvs1 ->
       v \in mvs0 ->
       subset mvs1 (diff fvn fvn0) -> subset mvs0 (diff fvngs1 fvn) -> undef_on initialH fvngs1.
-  Proof.
+  Proof using K_eq_dec mapspecs.
     Time map_solver mapspecs.
   Qed.
 
@@ -79,7 +79,7 @@ Section TestGoals.
       subset mvs1 (diff fvn fvn0) ->
       subset mvs0 (diff fvngs1 fvn) ->
       get midL v = Some w -> only_differ initialL mvs0 midL -> extends midL initialH.
-  Proof.
+  Proof using K_eq_dec mapspecs.
     Time map_solver mapspecs.
   Qed.
 
@@ -95,7 +95,7 @@ Section TestGoals.
       subset mvs1 (diff fvn fvn0) ->
       subset mvs0 (diff fvngs1 fvn) ->
       get midL v = Some w -> only_differ initialL mvs0 midL -> undef_on initialH fvn.
-  Proof.
+  Proof using K_eq_dec mapspecs.
     Time map_solver mapspecs.
   Qed.
 
@@ -113,7 +113,7 @@ Section TestGoals.
       get midL v = Some w ->
       only_differ initialL mvs0 midL ->
       get preFinalL v0 = Some w0 -> only_differ midL mvs1 preFinalL -> get preFinalL v = Some w.
-  Proof.
+  Proof using K_eq_dec mapspecs.
     Time map_solver mapspecs.
   Qed.
 
@@ -131,7 +131,7 @@ Section TestGoals.
       subset fvn0 fvn ->
       get initial2L v = Some cv ->
       only_differ initialL mvcondL initial2L -> extends initial2L initialH.
-  Proof.
+  Proof using K_eq_dec mapspecs.
     Time map_solver mapspecs.
   Qed.
 
@@ -150,7 +150,7 @@ Section TestGoals.
       get initial2L v = Some cv ->
       only_differ initialL mvcondL initial2L ->
       undef_on initialH fvn.
-  Proof.
+  Proof using K_eq_dec mapspecs.
     Time map_solver mapspecs.
   Qed.
 
@@ -160,7 +160,7 @@ Section TestGoals.
       PropSet.disjoint emv fvngs' ->
       undef_on initialH fvngs' ->
       extends initialL (remove initialH lhs).
-  Proof.
+  Proof using K_eq_dec mapspecs.
     Time map_solver mapspecs.
   Qed.
 
@@ -178,7 +178,7 @@ Section TestGoals.
       only_differ initialL mvs prefinalL ->
       v0 \in mvs ->
       subset mvs (diff fvngs fvngs') -> extends (put prefinalL lhs v) (put initialH lhs v).
-  Proof.
+  Proof using K_eq_dec mapspecs.
     Time map_solver mapspecs.
   Qed.
 
@@ -197,7 +197,7 @@ Section TestGoals.
       subset mvs0 (diff fvn fvngs') ->
       subset mvs (diff fvngs fvn) ->
       extends prefinalL initialH.
-  Proof.
+  Proof using K_eq_dec mapspecs.
     Time map_solver mapspecs.
   Qed.
 
@@ -214,7 +214,7 @@ Section TestGoals.
       v0 \in mvs0 ->
       v \in mvs ->
       subset mvs0 (diff fvn fvngs') -> subset mvs (diff fvngs fvn) -> undef_on initialH fvn.
-  Proof.
+  Proof using K_eq_dec mapspecs.
     Time map_solver mapspecs.
   Qed.
 
@@ -233,7 +233,7 @@ Section TestGoals.
       v0 \in mvs0 ->
       v \in mvs ->
       subset mvs0 (diff fvn fvngs') -> subset mvs (diff fvngs fvn) -> get finalL v = Some av.
-  Proof.
+  Proof using K_eq_dec mapspecs.
     Time map_solver mapspecs.
   Qed.
 
@@ -252,7 +252,7 @@ Section TestGoals.
       v0 \in mvs0 ->
       v \in mvs ->
       subset mvs0 (diff fvn fvngs') -> subset mvs (diff fvngs fvn) -> get finalL v = Some av.
-  Proof.
+  Proof using K_eq_dec mapspecs.
     Time map_solver mapspecs.
   Qed.
 
@@ -271,7 +271,7 @@ Section TestGoals.
       subset fvngs' fvngs ->
       subset fvngs' fvn ->
       extends middleL st2 -> only_differ initial2L mvsBody middleL -> extends middleL st2.
-  Proof.
+  Proof using K_eq_dec mapspecs.
     Time map_solver mapspecs.
   Qed.
 
@@ -293,7 +293,7 @@ Section TestGoals.
       only_differ initial2L mvsBody middleL ->
       only_differ initialH emv st2 ->
       undef_on st2 fvngs.
-  Proof.
+  Proof using K_eq_dec mapspecs.
     Time map_solver mapspecs.
   Qed.
 
@@ -314,7 +314,7 @@ Section TestGoals.
       v0 \in mvs0 ->
       v \in mvs ->
       subset mvs0 (diff fvn fvngs') -> subset mvs (diff fvngs fvn) -> extends finalL initialH.
-  Proof.
+  Proof using K_eq_dec mapspecs.
     Time map_solver mapspecs.
   Qed.
 

--- a/src/coqutil/Map/TestLemmas.v
+++ b/src/coqutil/Map/TestLemmas.v
@@ -20,84 +20,84 @@ Section Tests.
   Ltac t := map_solver stateMapSpecs.
 
   Lemma extends_refl: forall s, extends s s.
-  Proof. t. Qed.
+  Proof using stateMapSpecs var_eqb_spec. t. Qed.
 
   Lemma extends_trans: forall s1 s2 s3,
       extends s1 s2 ->
       extends s2 s3 ->
       extends s1 s3.
-  Proof. t. Qed.
+  Proof using stateMapSpecs var_eqb_spec. t. Qed.
 
   Lemma only_differ_union_l: forall s1 s2 r1 r2,
     only_differ s1 r1 s2 ->
     only_differ s1 (union r1 r2) s2.
-  Proof. t. Qed.
+  Proof using stateMapSpecs var_eqb_spec. t. Qed.
 
   Lemma only_differ_union_r: forall s1 s2 r1 r2,
     only_differ s1 r2 s2 ->
     only_differ s1 (union r1 r2) s2.
-  Proof. t. Qed.
+  Proof using stateMapSpecs var_eqb_spec. t. Qed.
 
   Lemma only_differ_one: forall s x v,
     only_differ s (singleton_set x) (put s x v).
-  Proof. t. Qed.
+  Proof using stateMapSpecs var_eqb_spec. t. Qed.
 
   Lemma only_differ_refl: forall s1 r,
     only_differ s1 r s1.
-  Proof. t. Qed.
+  Proof using stateMapSpecs var_eqb_spec. t. Qed.
 
   Lemma only_differ_sym: forall s1 s2 r,
     only_differ s1 r s2 ->
     only_differ s2 r s1.
-  Proof. t. Qed.
+  Proof using stateMapSpecs var_eqb_spec. t. Qed.
 
   Lemma only_differ_trans: forall s1 s2 s3 r,
     only_differ s1 r s2 ->
     only_differ s2 r s3 ->
     only_differ s1 r s3.
-  Proof. t. Qed.
+  Proof using stateMapSpecs var_eqb_spec. t. Qed.
 
   Lemma undef_on_shrink: forall st (vs1 vs2: var -> Prop),
     undef_on st vs1 ->
     subset vs2 vs1 ->
     undef_on st vs2.
-  Proof. t. Qed.
+  Proof using stateMapSpecs var_eqb_spec. t. Qed.
 
   Lemma only_differ_subset: forall s1 s2 (r1 r2: var -> Prop),
     subset r1 r2 ->
     only_differ s1 r1 s2 ->
     only_differ s1 r2 s2.
-  Proof. t. Qed.
+  Proof using stateMapSpecs var_eqb_spec. t. Qed.
 
   Lemma extends_if_only_differ_in_undef: forall s1 s2 s vs,
     extends s1 s ->
     undef_on s vs ->
     only_differ s1 vs s2 ->
     extends s2 s.
-  Proof. t. Qed.
+  Proof using stateMapSpecs var_eqb_spec. t. Qed.
 
   Lemma extends_if_only_differ_is_undef: forall s1 s2 vs,
     undef_on s1 vs ->
     only_differ s1 vs s2 ->
     extends s2 s1.
-  Proof. t. Qed.
+  Proof using stateMapSpecs var_eqb_spec. t. Qed.
 
   Lemma extends_put_same: forall s1 s2 x v,
     extends s2 s1 ->
     extends (put s2 x v) (put s1 x v).
-  Proof. t. Qed.
+  Proof using stateMapSpecs var_eqb_spec. t. Qed.
 
   Lemma only_differ_get_unchanged: forall s1 s2 x v d,
     get s1 x = v ->
     only_differ s1 d s2 ->
     ~ elem_of x d ->
     get s2 x = v.
-  Proof. t. Qed.
+  Proof using stateMapSpecs var_eqb_spec. t. Qed.
 
   Lemma only_differ_put: forall s (d: set var) x v,
     elem_of x d ->
     only_differ s d (put s x v).
-  Proof. t. Qed.
+  Proof using stateMapSpecs var_eqb_spec. t. Qed.
 
 End Tests.
 

--- a/src/coqutil/Tactics/eplace.v
+++ b/src/coqutil/Tactics/eplace.v
@@ -1,14 +1,19 @@
 (* COQBUG: https://github.com/coq/coq/issues/4494 *)
 (* COQBUG: https://github.com/coq/coq/issues/14124 *)
 
+(* Work around type inference issue in Coq <= 8.12 *)
+Ltac eplace_sym_hyp Hrw :=
+  lazymatch type of Hrw with
+  | @eq ?A ?x ?y => constr:(@eq_sym A x y Hrw)
+  end.
 Ltac eplace_with_at_by lhs rhs set_tac tac :=
   let LHS := fresh "_eplace_with_at_by_LHS" in set_tac LHS lhs;
   let Hrw := fresh "_eplace_with_at_by_Hrw" in assert (Hrw : LHS = rhs) by (subst LHS; tac);
-  clearbody LHS; induction (eq_sym Hrw); clear Hrw.
+  clearbody LHS; let Hrw' := eplace_sym_hyp Hrw in induction Hrw'; clear Hrw.
 Ltac eplace_with_at lhs rhs set_tac :=
   let LHS := fresh "_eplace_with_at_LHS" in set_tac LHS lhs;
   let Hrw := fresh "_eplace_with_at_Hrw" in assert (Hrw : LHS = rhs);
-  [subst LHS | clearbody LHS; induction (eq_sym Hrw); clear Hrw ].
+  [subst LHS | clearbody LHS; let Hrw' := eplace_sym_hyp Hrw in induction Hrw'; clear Hrw ].
 
 Tactic Notation "eplace" uconstr(x) "with" open_constr(y) :=
 eplace_with_at x y ltac:(fun x' x => set (x' := x) ).

--- a/src/coqutil/Word/DebugWordEq.v
+++ b/src/coqutil/Word/DebugWordEq.v
@@ -11,7 +11,7 @@ Section WithWord.
        constants [word_cst]).
 
   Lemma reduce_eq_to_diff0: forall (a b: word), word.sub a b = word.of_Z 0 -> a = b.
-  Proof.
+  Proof using word_ok.
     intros a b X.
     replace a with (word.add b (word.sub a b)) by ring.
     rewrite X.

--- a/src/coqutil/Word/Naive.v
+++ b/src/coqutil/Word/Naive.v
@@ -70,17 +70,17 @@ Section WithWidth.
   |}.
 
   Lemma eq_unsigned {x y : rep} : unsigned x = unsigned y -> x = y.
-  Proof.
+  Proof using Type.
     cbv [value]; destruct x as [x px], y as [y py]; cbn.
     intro; subst y.
     apply f_equal, Eqdep_dec.UIP_dec. eapply Z.eq_dec.
   Qed.
 
   Lemma of_Z_unsigned x : wrap (unsigned x) = x.
-  Proof. eapply eq_unsigned; destruct x; cbn; assumption.  Qed.
+  Proof using Type. eapply eq_unsigned; destruct x; cbn; assumption.  Qed.
 
   Lemma signed_of_Z z : signed (wrap z) = wrap_value (z + 2 ^ (width - 1)) - 2 ^ (width - 1).
-  Proof.
+  Proof using Type.
     cbv [unsigned signed wrap wrap_value swrap_value].
     rewrite Zdiv.Zplus_mod_idemp_l; auto.
   Qed.
@@ -88,7 +88,7 @@ Section WithWidth.
   Context (width_nonneg : Z.lt 0 width).
 
   Global Instance ok : word.ok word.
-  Proof.
+  Proof using width_nonneg.
     split; intros;
       repeat match goal with
              | a: @word.rep _ _ |- _ => destruct a

--- a/src/coqutil/Word/Properties.v
+++ b/src/coqutil/Word/Properties.v
@@ -54,7 +54,7 @@ Module word.
     Lemma signed_eq_swrap_unsigned x : signed x = swrap (unsigned x).
     Proof using word_ok. cbv [wrap]; rewrite <-signed_of_Z, of_Z_unsigned; trivial. Qed.
 
-    Lemma width_nonneg : 0 <= width. pose proof using word_ok width_pos. blia. Qed.
+    Lemma width_nonneg : 0 <= width. Proof using word_ok. pose proof width_pos. blia. Qed.
     Let width_nonneg_context : 0 <= width. apply width_nonneg. Qed.
     Lemma modulus_pos : 0 < 2^width. apply Z.pow_pos_nonneg; firstorder idtac. Qed.
     Let modulus_pos_section_context := modulus_pos.

--- a/src/coqutil/Word/Properties.v
+++ b/src/coqutil/Word/Properties.v
@@ -23,47 +23,47 @@ Module word.
   : word_laws.
 
     Lemma wrap_unsigned x : (unsigned x) mod (2^width) = unsigned x.
-    Proof.
+    Proof using word_ok.
       pose proof unsigned_of_Z (unsigned x) as H.
       rewrite of_Z_unsigned in H. unfold wrap in *. congruence.
     Qed.
 
     Lemma unsigned_of_Z_0 : word.unsigned (word.of_Z 0) = 0.
-    Proof.
+    Proof using word_ok.
       rewrite word.unsigned_of_Z; cbv [wrap]; rewrite Z.mod_small; trivial; [].
       split; try blia.
       epose proof proj1 (Z.pow_gt_1 2 width ltac:(blia)) word.width_pos; blia.
     Qed.
 
     Lemma unsigned_inj x y (H : unsigned x = unsigned y) : x = y.
-    Proof. rewrite <-(of_Z_unsigned x), <-(of_Z_unsigned y). apply f_equal, H. Qed.
+    Proof using word_ok. rewrite <-(of_Z_unsigned x), <-(of_Z_unsigned y). apply f_equal, H. Qed.
 
     Lemma unsigned_of_Z_nowrap x:
       0 <= x < 2 ^ width -> word.unsigned (word.of_Z x) = x.
-    Proof.
+    Proof using word_ok.
       intros. rewrite word.unsigned_of_Z. unfold word.wrap. rewrite Z.mod_small; trivial.
     Qed.
 
     Lemma of_Z_inj_small{x y}:
       word.of_Z x = word.of_Z y -> 0 <= x < 2 ^ width -> 0 <= y < 2 ^ width -> x = y.
-    Proof.
+    Proof using word_ok.
       intros. apply (f_equal word.unsigned) in H. rewrite ?word.unsigned_of_Z in H.
       unfold word.wrap in H. rewrite ?Z.mod_small in H by assumption. assumption.
     Qed.
 
     Lemma signed_eq_swrap_unsigned x : signed x = swrap (unsigned x).
-    Proof. cbv [wrap]; rewrite <-signed_of_Z, of_Z_unsigned; trivial. Qed.
+    Proof using word_ok. cbv [wrap]; rewrite <-signed_of_Z, of_Z_unsigned; trivial. Qed.
 
-    Lemma width_nonneg : 0 <= width. pose proof width_pos. blia. Qed.
+    Lemma width_nonneg : 0 <= width. pose proof using word_ok width_pos. blia. Qed.
     Let width_nonneg_context : 0 <= width. apply width_nonneg. Qed.
     Lemma modulus_pos : 0 < 2^width. apply Z.pow_pos_nonneg; firstorder idtac. Qed.
     Let modulus_pos_section_context := modulus_pos.
 
     Lemma unsigned_range x : 0 <= unsigned x < 2^width.
-    Proof. rewrite <-wrap_unsigned. mia. Qed.
+    Proof using modulus_pos_section_context. rewrite <-wrap_unsigned. mia. Qed.
 
     Lemma ring_theory : Ring_theory.ring_theory (of_Z 0) (of_Z 1) add mul sub opp Logic.eq.
-    Proof.
+    Proof using modulus_pos_section_context.
      split; intros; apply unsigned_inj; repeat (rewrite ?wrap_unsigned,
          ?unsigned_add, ?unsigned_sub, ?unsigned_opp, ?unsigned_mul, ?unsigned_of_Z,
          ?Z.add_mod_idemp_l, ?Z.add_mod_idemp_r, ?Z.mul_mod_idemp_l, ?Z.mul_mod_idemp_r,
@@ -79,22 +79,22 @@ Module word.
          ?Z.sub_0_l, ?Z.add_0_l, ?(Z.mod_small 1), ?Z.mul_1_l by auto with zarith) || unfold wrap);
        try solve [f_equal; auto with zarith].
     Lemma ring_morph_add : forall x y : Z, of_Z (x + y) = add (of_Z x) (of_Z y).
-    Proof. prove_ring_morph. Qed.
+    Proof using modulus_pos_section_context. prove_ring_morph. Qed.
     Lemma ring_morph_sub : forall x y : Z, of_Z (x - y) = sub (of_Z x) (of_Z y).
-    Proof. prove_ring_morph. Qed.
+    Proof using word_ok. prove_ring_morph. Qed.
     Lemma ring_morph_mul : forall x y : Z, of_Z (x * y) = mul (of_Z x) (of_Z y).
-    Proof. prove_ring_morph. Qed.
+    Proof using modulus_pos_section_context. prove_ring_morph. Qed.
     Lemma ring_morph_opp : forall x : Z, of_Z (- x) = opp (of_Z x).
-    Proof.
+    Proof using word_ok.
       prove_ring_morph.
       rewrite <-Z.sub_0_l; symmetry; rewrite <-Z.sub_0_l, Zdiv.Zminus_mod_idemp_r. auto.
     Qed.
     Lemma ring_morph_eqb : forall x y : Z, Zbool.Zeq_bool x y = true -> of_Z x = of_Z y.
-    Proof. intros. f_equal. apply Zbool.Zeq_is_eq_bool. assumption. Qed.
+    Proof using Type. intros. f_equal. apply Zbool.Zeq_is_eq_bool. assumption. Qed.
     Lemma ring_morph :
       Ring_theory.ring_morph (of_Z 0) (of_Z 1) add   mul   sub   opp   Logic.eq
                              0        1        Z.add Z.mul Z.sub Z.opp Zbool.Zeq_bool of_Z.
-    Proof.
+    Proof using modulus_pos_section_context.
       split; auto using ring_morph_add, ring_morph_sub, ring_morph_mul,
                         ring_morph_opp, ring_morph_eqb.
     Qed.
@@ -108,11 +108,11 @@ Module word.
              end.
 
     Lemma unsigned_mulhuu_nowrap x y : unsigned (mulhuu x y) = Z.mul (unsigned x) (unsigned y) / 2^width.
-    Proof. autorewrite with word_laws; unfold wrap; generalize_wrap_unsigned; rewrite Z.mod_small; mia. Qed.
+    Proof using modulus_pos_section_context. autorewrite with word_laws; unfold wrap; generalize_wrap_unsigned; rewrite Z.mod_small; mia. Qed.
     Lemma unsigned_divu_nowrap x y (H:unsigned y <> 0) : unsigned (divu x y) = Z.div (unsigned x) (unsigned y).
-    Proof. autorewrite with word_laws; unfold wrap; generalize_wrap_unsigned; rewrite Z.mod_small; mia. Qed.
+    Proof using modulus_pos_section_context. autorewrite with word_laws; unfold wrap; generalize_wrap_unsigned; rewrite Z.mod_small; mia. Qed.
     Lemma unsigned_modu_nowrap x y (H:unsigned y <> 0) : unsigned (modu x y) = Z.modulo (unsigned x) (unsigned y).
-    Proof. autorewrite with word_laws; unfold wrap; generalize_wrap_unsigned; rewrite Z.mod_small; mia. Qed.
+    Proof using modulus_pos_section_context. autorewrite with word_laws; unfold wrap; generalize_wrap_unsigned; rewrite Z.mod_small; mia. Qed.
 
     Ltac bitwise :=
       autorewrite with word_laws;
@@ -121,15 +121,15 @@ Module word.
       Z.bitblast.
 
     Lemma unsigned_or_nowrap x y : unsigned (or x y) = Z.lor (unsigned x) (unsigned y).
-    Proof. bitwise. Qed.
+    Proof using width_nonneg_context. bitwise. Qed.
     Lemma unsigned_and_nowrap x y : unsigned (and x y) = Z.land (unsigned x) (unsigned y).
-    Proof. bitwise. Qed.
+    Proof using width_nonneg_context. bitwise. Qed.
     Lemma unsigned_xor_nowrap x y : unsigned (xor x y) = Z.lxor (unsigned x) (unsigned y).
-    Proof. bitwise. Qed.
+    Proof using width_nonneg_context. bitwise. Qed.
     Lemma unsigned_ndn_nowrap x y : unsigned (ndn x y) = Z.ldiff (unsigned x) (unsigned y).
-    Proof. bitwise. Qed.
+    Proof using width_nonneg_context. bitwise. Qed.
     Lemma unsigned_sru_nowrap x y (H:unsigned y < width) : unsigned (sru x y) = Z.shiftr (unsigned x) (unsigned y).
-    Proof.
+    Proof using modulus_pos_section_context.
       pose proof unsigned_range y.
       rewrite unsigned_sru by blia.
       unfold wrap.
@@ -138,54 +138,54 @@ Module word.
     Qed.
 
     Lemma testbit_wrap z i : Z.testbit (wrap z) i = ((i <? width) && Z.testbit z i)%bool.
-    Proof. cbv [wrap]. Z.rewrite_bitwise; trivial. Qed.
+    Proof using Type. cbv [wrap]. Z.rewrite_bitwise; trivial. Qed.
 
     Lemma eqb_true: forall (a b: word), word.eqb a b = true -> a = b.
-    Proof.
+    Proof using word_ok.
       intros.
       rewrite word.unsigned_eqb in H. rewrite Z.eqb_eq in H. apply unsigned_inj in H.
       assumption.
     Qed.
 
     Lemma eqb_eq: forall (a b: word), a = b -> word.eqb a b = true.
-    Proof.
+    Proof using word_ok.
       intros. subst. rewrite unsigned_eqb. apply Z.eqb_refl.
     Qed.
 
     Lemma eqb_false: forall (a b: word), word.eqb a b = false -> a <> b.
-    Proof.
+    Proof using word_ok.
       intros. intro. rewrite eqb_eq in H; congruence.
     Qed.
 
     Lemma eqb_ne: forall (a b: word), a <> b -> word.eqb a b = false.
-    Proof.
+    Proof using word_ok.
       intros. destruct (word.eqb a b) eqn: E; try congruence.
       exfalso. apply H. apply eqb_true in E. assumption.
     Qed.
 
     Lemma eqb_spec(a b: word): BoolSpec (a = b) (a <> b) (word.eqb a b).
-    Proof.
+    Proof using word_ok.
       destruct (eqb a b) eqn: E; constructor.
       - eauto using eqb_true.
       - eauto using eqb_false.
     Qed.
 
     Lemma eq_or_neq (k1 k2 : word) : k1 = k2 \/ k1 <> k2.
-    Proof. destruct (word.eqb k1 k2) eqn:H; [eapply eqb_true in H | eapply eqb_false in H]; auto. Qed.
+    Proof using word_ok. destruct (word.eqb k1 k2) eqn:H; [eapply eqb_true in H | eapply eqb_false in H]; auto. Qed.
 
     Let width_nonzero : 0 < width. apply width_pos. Qed.
     Lemma half_modulus_pos : 0 < 2^(width-1). apply Z.pow_pos_nonneg; auto with zarith. Qed.
     Let half_modulus_pos_section_context := half_modulus_pos.
     Let twice_halfm : 2^(width-1) * 2 = 2^width.
-    Proof. rewrite Z.mul_comm, <-Z.pow_succ_r by blia; f_equal; blia. Qed.
+    Proof using width_nonzero. rewrite Z.mul_comm, <-Z.pow_succ_r by blia; f_equal; blia. Qed.
 
     Lemma unsigned_of_Z_1 : word.unsigned (word.of_Z 1) = 1.
-    Proof.
+    Proof using half_modulus_pos_section_context twice_halfm.
       rewrite word.unsigned_of_Z; cbv [wrap]; rewrite Z.mod_small; trivial; []; blia.
     Qed.
 
     Lemma unsigned_of_Z_minus1 : word.unsigned (word.of_Z (-1)) = Z.ones width.
-    Proof.
+    Proof using half_modulus_pos_section_context modulus_pos_section_context twice_halfm.
       rewrite word.unsigned_of_Z; cbv [wrap].
       change (-1) with (Z.opp 1).
       rewrite Z.mod_opp_l_nz; rewrite ?Z.mod_small; try blia; [].
@@ -194,16 +194,16 @@ Module word.
     Qed.
 
     Lemma signed_range x : -2^(width-1) <= signed x < 2^(width-1).
-    Proof.
+    Proof using modulus_pos_section_context twice_halfm.
       rewrite signed_eq_swrap_unsigned. cbv [swrap].
       rewrite <-twice_halfm. mia.
     Qed.
 
     Lemma swrap_inrange z (H : -2^(width-1) <= z < 2^(width-1)) : swrap z = z.
-    Proof. cbv [swrap]; rewrite Z.mod_small; blia. Qed.
+    Proof using twice_halfm. cbv [swrap]; rewrite Z.mod_small; blia. Qed.
 
     Lemma swrap_as_div_mod z : swrap z = z mod 2^(width-1) - 2^(width-1) * (z / (2^(width - 1)) mod 2).
-    Proof.
+    Proof using half_modulus_pos_section_context twice_halfm.
       symmetry; cbv [swrap wrap].
       replace (2^width) with ((2 ^ (width - 1) * 2))
         by (rewrite Z.mul_comm, <-Z.pow_succ_r by blia; f_equal; blia).
@@ -213,7 +213,7 @@ Module word.
     Qed.
 
     Lemma pow2_width_minus1: 2 ^ width = 2 * 2 ^ (width - 1).
-    Proof. rewrite <-Z.pow_succ_r, Z.sub_1_r, Z.succ_pred; blia. Qed.
+    Proof using width_nonzero. rewrite <-Z.pow_succ_r, Z.sub_1_r, Z.succ_pred; blia. Qed.
 
     Ltac prove_signed_op :=
       rewrite !signed_eq_swrap_unsigned;
@@ -223,22 +223,22 @@ Module word.
       Z.mod_equality.
 
     Lemma signed_add x y : signed (add x y) = swrap (Z.add (signed x) (signed y)).
-    Proof. prove_signed_op. Qed.
+    Proof using width_nonzero. prove_signed_op. Qed.
 
     Lemma signed_sub x y : signed (sub x y) = swrap (Z.sub (signed x) (signed y)).
-    Proof. prove_signed_op. Qed.
+    Proof using width_nonzero. prove_signed_op. Qed.
 
     Lemma signed_opp x : signed (opp x) = swrap (Z.opp (signed x)).
-    Proof. prove_signed_op. Qed.
+    Proof using width_nonzero. prove_signed_op. Qed.
 
     Lemma signed_mul x y : signed (mul x y) = swrap (Z.mul (signed x) (signed y)).
-    Proof. prove_signed_op. Qed.
+    Proof using width_nonzero. prove_signed_op. Qed.
 
     Lemma testbit_swrap z i : Z.testbit (swrap z) i
                               = if i <? width
                                 then Z.testbit (wrap z) i
                                 else Z.testbit (wrap z) (width -1).
-    Proof.
+    Proof using Type.
       destruct (ZArith_dec.Z_lt_le_dec i 0).
       { destruct (Z.ltb_spec i width); rewrite ?Z.testbit_neg_r by blia; trivial. }
       rewrite swrap_as_div_mod. cbv [wrap].
@@ -262,7 +262,7 @@ Module word.
                                = if i <? width
                                  then Z.testbit (unsigned x) i
                                  else Z.testbit (unsigned x) (width -1).
-    Proof.
+    Proof using half_modulus_pos_section_context twice_halfm width_nonneg_context.
       rewrite <-wrap_unsigned, signed_eq_swrap_unsigned.
       eapply testbit_swrap; assumption.
     Qed.
@@ -278,42 +278,42 @@ Module word.
       end.
 
     Lemma swrap_signed x : swrap (signed x) = signed x.
-    Proof. rewrite signed_eq_swrap_unsigned. sbitwise. Qed.
+    Proof using half_modulus_pos_section_context twice_halfm width_nonneg_context. rewrite signed_eq_swrap_unsigned. sbitwise. Qed.
 
     Lemma signed_or x y (H : Z.lt (unsigned y) width) : signed (or x y) = swrap (Z.lor (signed x) (signed y)).
-    Proof. sbitwise. Qed.
+    Proof using half_modulus_pos_section_context twice_halfm width_nonneg_context. sbitwise. Qed.
     Lemma signed_and x y : signed (and x y) = swrap (Z.land (signed x) (signed y)).
-    Proof. sbitwise. Qed.
+    Proof using half_modulus_pos_section_context twice_halfm width_nonneg_context. sbitwise. Qed.
     Lemma signed_xor x y : signed (xor x y) = swrap (Z.lxor (signed x) (signed y)).
-    Proof. sbitwise. Qed.
+    Proof using half_modulus_pos_section_context twice_halfm width_nonneg_context. sbitwise. Qed.
     Lemma signed_not x : signed (not x) = swrap (Z.lnot (signed x)).
-    Proof. sbitwise. Qed.
+    Proof using half_modulus_pos_section_context twice_halfm width_nonneg_context. sbitwise. Qed.
     Lemma signed_ndn x y : signed (ndn x y) = swrap (Z.ldiff (signed x) (signed y)).
-    Proof. sbitwise. Qed.
+    Proof using half_modulus_pos_section_context twice_halfm width_nonneg_context. sbitwise. Qed.
 
     Lemma signed_or_nowrap x y (H : Z.lt (unsigned y) width) : signed (or x y) = Z.lor (signed x) (signed y).
-    Proof. sbitwise. Qed.
+    Proof using half_modulus_pos_section_context twice_halfm width_nonneg_context. sbitwise. Qed.
     Lemma signed_and_nowrap x y : signed (and x y) = Z.land (signed x) (signed y).
-    Proof. sbitwise. Qed.
+    Proof using half_modulus_pos_section_context twice_halfm width_nonneg_context. sbitwise. Qed.
     Lemma signed_xor_nowrap x y : signed (xor x y) = Z.lxor (signed x) (signed y).
-    Proof. sbitwise. Qed.
+    Proof using half_modulus_pos_section_context twice_halfm width_nonneg_context. sbitwise. Qed.
     Lemma signed_not_nowrap x : signed (not x) = Z.lnot (signed x).
-    Proof. sbitwise. Qed.
+    Proof using half_modulus_pos_section_context twice_halfm width_nonneg_context. sbitwise. Qed.
     Lemma signed_ndn_nowrap x y : signed (ndn x y) = Z.ldiff (signed x) (signed y).
-    Proof. sbitwise. Qed.
+    Proof using half_modulus_pos_section_context twice_halfm width_nonneg_context. sbitwise. Qed.
 
     Lemma signed_srs_nowrap x y (H:unsigned y < width) : signed (srs x y) = Z.shiftr (signed x) (unsigned y).
-    Proof.
+    Proof using half_modulus_pos_section_context modulus_pos_section_context twice_halfm.
       pose proof unsigned_range y; sbitwise.
       replace (unsigned y) with 0 by blia; rewrite Z.add_0_r; trivial.
     Qed.
 
     Lemma signed_mulhss_nowrap x y : signed (mulhss x y) = Z.mul (signed x) (signed y) / 2^width.
-    Proof. rewrite signed_mulhss. apply swrap_inrange. pose (signed_range x); pose (signed_range y). mia. Qed.
+    Proof using half_modulus_pos_section_context modulus_pos_section_context twice_halfm. rewrite signed_mulhss. apply swrap_inrange. pose (signed_range x); pose (signed_range y). mia. Qed.
     Lemma signed_mulhsu_nowrap x y : signed (mulhsu x y) = Z.mul (signed x) (unsigned y) / 2^width.
-    Proof. rewrite signed_mulhsu. apply swrap_inrange. pose (signed_range x); pose proof (unsigned_range y). mia. Qed.
+    Proof using modulus_pos_section_context twice_halfm. rewrite signed_mulhsu. apply swrap_inrange. pose (signed_range x); pose proof (unsigned_range y). mia. Qed.
     Lemma signed_divs_nowrap x y (H:signed y <> 0) (H0:signed x <> -2^(width-1) \/ signed y <> -1) : signed (divs x y) = Z.quot (signed x) (signed y).
-    Proof.
+    Proof using half_modulus_pos_section_context modulus_pos_section_context twice_halfm.
       rewrite signed_divs by assumption. apply swrap_inrange.
       rewrite Z.quot_div by assumption. pose proof (signed_range x).
       destruct (Z.sgn_spec (signed x)) as [[? X]|[[? X]|[? X]]];
@@ -321,7 +321,7 @@ Module word.
       rewrite ?X, ?Y; rewrite ?Z.abs_eq, ?Z.abs_neq by blia; mia.
     Qed.
     Lemma signed_mods_nowrap x y (H:signed y <> 0) : signed (mods x y) = Z.rem (signed x) (signed y).
-    Proof.
+    Proof using half_modulus_pos_section_context modulus_pos_section_context twice_halfm.
       rewrite signed_mods by assumption. apply swrap_inrange.
       rewrite Z.rem_mod by assumption.
       pose (signed_range x); pose (signed_range y).
@@ -331,7 +331,7 @@ Module word.
     Qed.
 
     Lemma signed_inj x y (H : signed x = signed y) : x = y.
-    Proof.
+    Proof using half_modulus_pos_section_context twice_halfm width_nonneg_context.
       eapply unsigned_inj, Z.bits_inj'; intros i Hi.
       eapply (f_equal (fun z => Z.testbit z i)) in H.
       rewrite 2testbit_signed in H. rewrite <-(wrap_unsigned x), <-(wrap_unsigned y).
@@ -340,7 +340,7 @@ Module word.
     Qed.
 
     Lemma of_Z_signed: forall x: word, of_Z (signed x) = x.
-    Proof.
+    Proof using half_modulus_pos_section_context twice_halfm width_nonneg_context.
       intros.
       apply signed_inj.
       rewrite signed_of_Z.
@@ -349,12 +349,12 @@ Module word.
 
     Lemma signed_of_Z_nowrap x :
       - 2^(width-1) <= x < 2 ^ (width-1) -> word.signed (word.of_Z x) = x.
-    Proof.
+    Proof using twice_halfm.
       intros; rewrite signed_of_Z. cbv [swrap]; rewrite Z.mod_small; Lia.lia.
     Qed.
 
     Lemma signed_eqb x y : eqb x y = Z.eqb (signed x) (signed y).
-    Proof.
+    Proof using half_modulus_pos_section_context twice_halfm width_nonneg_context.
       rewrite unsigned_eqb.
       destruct (Z.eqb_spec (unsigned x) (unsigned y)) as [?e|?];
         destruct (Z.eqb_spec (  signed x) (  signed y)) as [?e|?];
@@ -366,13 +366,13 @@ Module word.
     Context {width} {word : word width} {word_ok : word.ok word}.
     Local Hint Mode word.word - : typeclass_instances.
     Lemma word_sub_add_l_same_l x y : word.sub (word.add x y) x = y.
-    Proof.
+    Proof using word_ok.
       eapply word.unsigned_inj.
       rewrite <- (wrap_unsigned y), unsigned_sub, unsigned_add;
         cbv [wrap]; rewrite Zdiv.Zminus_mod_idemp_l. f_equal; blia.
     Qed.
     Lemma word_sub_add_l_same_r x y : word.sub (word.add y x) x = y.
-    Proof.
+    Proof using word_ok.
       eapply word.unsigned_inj.
       rewrite <- (wrap_unsigned y), unsigned_sub, unsigned_add;
         cbv [wrap]; rewrite Zdiv.Zminus_mod_idemp_l; f_equal; blia.
@@ -380,7 +380,7 @@ Module word.
 
     Lemma decrement_nonzero_lt x (H : word.unsigned x <> 0) :
       word.unsigned (word.sub x (word.of_Z 1)) < word.unsigned x.
-    Proof.
+    Proof using word_ok.
       pose proof word.unsigned_range x; pose proof modulus_pos.
       rewrite word.unsigned_sub, word.unsigned_of_Z_1.
       unfold word.wrap. Z.div_mod_to_equations.
@@ -388,7 +388,7 @@ Module word.
     Qed.
 
     Lemma well_founded_lt_unsigned : well_founded (fun a b : word => word.unsigned a < word.unsigned b).
-    Proof.
+    Proof using word_ok.
       simple refine (Wf_nat.well_founded_lt_compat _ (fun x => Z.to_nat (word.unsigned x)) _ _).
       cbv beta; intros a b H.
       epose proof proj1 (Properties.word.unsigned_range a); epose proof proj1 (Properties.word.unsigned_range b).
@@ -398,19 +398,19 @@ Module word.
     Qed.
 
     Lemma if_zero (t:bool) (H : unsigned (if t then of_Z 1 else of_Z 0) = 0) : t = false.
-    Proof. destruct t; trivial; []. rewrite unsigned_of_Z_1 in H; inversion H. Qed.
+    Proof using word_ok. destruct t; trivial; []. rewrite unsigned_of_Z_1 in H; inversion H. Qed.
     Lemma if_nonzero (t:bool) (H : unsigned (if t then of_Z 1 else of_Z 0) <> 0) : t = true.
-    Proof. destruct t; trivial; []. rewrite unsigned_of_Z_0 in H. case (H eq_refl). Qed.
+    Proof using word_ok. destruct t; trivial; []. rewrite unsigned_of_Z_0 in H. case (H eq_refl). Qed.
 
     Lemma unsigned_if: forall (b: bool) thn els,
         word.unsigned (if b then thn else els) = if b then word.unsigned thn else word.unsigned els.
-    Proof. intros. destruct b; reflexivity. Qed.
+    Proof using Type. intros. destruct b; reflexivity. Qed.
 
     Lemma and_bool_to_word: forall (b1 b2: bool),
         word.and (if b1 then word.of_Z 1 else word.of_Z 0)
                  (if b2 then word.of_Z 1 else word.of_Z 0) =
         if (andb b1 b2) then word.of_Z 1 else word.of_Z 0.
-    Proof.
+    Proof using word_ok.
       assert (1 < 2 ^ width). {
         pose proof word.width_pos.
         change 1 with (2 ^ 0). apply Z.pow_lt_mono_r; blia.
@@ -425,7 +425,7 @@ Module word.
         word.or (if b1 then word.of_Z 1 else word.of_Z 0)
                 (if b2 then word.of_Z 1 else word.of_Z 0) =
         if (orb b1 b2) then word.of_Z 1 else word.of_Z 0.
-    Proof.
+    Proof using word_ok.
       assert (1 < 2 ^ width). {
         pose proof word.width_pos.
         change 1 with (2 ^ 0). apply Z.pow_lt_mono_r; blia.
@@ -439,7 +439,7 @@ Module word.
     Lemma unsigned_slu_shamtZ: forall (x: word) (a: Z),
         0 <= a < width ->
         word.unsigned (word.slu x (word.of_Z a)) = word.wrap (Z.shiftl (word.unsigned x) a).
-    Proof.
+    Proof using Type.
       intros. assert (width <= 2 ^ width) by (apply Zpow_facts.Zpower2_le_lin; blia).
       rewrite word.unsigned_slu; rewrite word.unsigned_of_Z; unfold word.wrap; rewrite (Z.mod_small a); blia.
     Qed.
@@ -447,7 +447,7 @@ Module word.
     Lemma unsigned_sru_shamtZ: forall (x: word) (a: Z),
         0 <= a < width ->
         word.unsigned (word.sru x (word.of_Z a)) = Z.shiftr (word.unsigned x) a.
-    Proof.
+    Proof using word_ok.
       intros. assert (width <= 2 ^ width) by (apply Zpow_facts.Zpower2_le_lin; blia).
       rewrite word.unsigned_sru_nowrap; rewrite word.unsigned_of_Z;
         unfold word.wrap; rewrite (Z.mod_small a); blia.
@@ -456,7 +456,7 @@ Module word.
     Lemma signed_srs_shamtZ: forall (x: word) (a: Z),
         0 <= a < width ->
         word.signed (word.srs x (word.of_Z a)) = Z.shiftr (word.signed x) a.
-    Proof.
+    Proof using word_ok.
       intros. assert (width <= 2 ^ width) by (apply Zpow_facts.Zpower2_le_lin; blia).
       rewrite word.signed_srs_nowrap; rewrite word.unsigned_of_Z;
         unfold word.wrap; rewrite (Z.mod_small a); blia.
@@ -465,14 +465,14 @@ Module word.
     Add Ring wring: (@word.ring_theory width word word_ok).
 
     Lemma add_assoc: forall (x y z: word), word.add x (word.add y z) = word.add (word.add x y) z.
-    Proof. intros. ring. Qed.
+    Proof using word_ok. intros. ring. Qed.
     Lemma mul_assoc: forall (x y z: word), word.mul x (word.mul y z) = word.mul (word.mul x y) z.
-    Proof. intros. ring. Qed.
+    Proof using word_ok. intros. ring. Qed.
 
     Lemma of_Z_inj_mod: forall x y,
         x mod 2 ^ width = y mod 2 ^ width ->
         word.of_Z x = word.of_Z y.
-    Proof.
+    Proof using word_ok.
       intros.
       apply word.unsigned_inj.
       rewrite ?word.unsigned_of_Z.
@@ -483,7 +483,7 @@ Module word.
     Lemma of_Z_eq_by_moddiff0: forall x y,
         (x - y) mod 2 ^ width = 0 ->
         word.of_Z x = word.of_Z y.
-    Proof.
+    Proof using word_ok.
       intros. apply of_Z_inj_mod.
       apply Z.mod_divide in H; cycle 1. {
         pose proof word.width_pos.

--- a/src/coqutil/Word/SimplWordExpr.v
+++ b/src/coqutil/Word/SimplWordExpr.v
@@ -12,17 +12,17 @@ Section Lemmas.
 
   Add Ring wring: (@word.ring_theory width word word_ok).
 
-  Lemma add_0_l: forall x, word.add (word.of_Z 0) x = x. Proof. intros. ring. Qed.
-  Lemma add_0_r: forall x, word.add x (word.of_Z 0) = x. Proof. intros. ring. Qed.
-  Lemma mul_0_l: forall x, word.mul (word.of_Z 0) x = word.of_Z 0. Proof. intros. ring. Qed.
-  Lemma mul_0_r: forall x, word.mul x (word.of_Z 0) = word.of_Z 0. Proof. intros. ring. Qed.
-  Lemma mul_1_l: forall x, word.mul (word.of_Z 1) x = x. Proof. intros. ring. Qed.
-  Lemma mul_1_r: forall x, word.mul x (word.of_Z 1) = x. Proof. intros. ring. Qed.
+  Lemma add_0_l: forall x, word.add (word.of_Z 0) x = x. Proof using word_ok. intros. ring. Qed.
+  Lemma add_0_r: forall x, word.add x (word.of_Z 0) = x. Proof using word_ok. intros. ring. Qed.
+  Lemma mul_0_l: forall x, word.mul (word.of_Z 0) x = word.of_Z 0. Proof using word_ok. intros. ring. Qed.
+  Lemma mul_0_r: forall x, word.mul x (word.of_Z 0) = word.of_Z 0. Proof using word_ok. intros. ring. Qed.
+  Lemma mul_1_l: forall x, word.mul (word.of_Z 1) x = x. Proof using word_ok. intros. ring. Qed.
+  Lemma mul_1_r: forall x, word.mul x (word.of_Z 1) = x. Proof using word_ok. intros. ring. Qed.
 
   Lemma sextend_width_nop: forall (w v: Z),
     w = width ->
     word.of_Z (BitOps.signExtend w v) = word.of_Z v.
-  Proof.
+  Proof using word_ok.
     intros. subst. unfold BitOps.signExtend. apply word.unsigned_inj.
     rewrite! word.unsigned_of_Z.
     pose proof (@word.width_pos _ _ word_ok).


### PR DESCRIPTION
On top of #38 and #39

Remaining errors are:
File "src/coqutil/Ltac2Lib/Msg.v", line 4, characters 2-16:
Error: Unbound value List.fold_left
File "src/coqutil/Ltac2Lib/Constr.v", line 19, characters 4-22:
Error: Constructor Unsafe.Fix expects 5 arguments, but is applied to 4 arguments
File "src/coqutil/Ltac2Lib/Log.v", line 4, characters 33-47:
Error: Unbound value List.fold_left
File "src/coqutil/Tactics/Records.v", line 38, characters 13-24:
Error: Unbound value Array.empty
File "src/coqutil/Word/ZifyLittleEndian.v", line 19, characters 0-30:
Error: Zify InjTyp: no table or option of this type

And also the fixable:
https://github.com/mit-plv/coqutil/blob/7969ad785931cb7eb42daeefbd6fbf951ac1fea5/src/coqutil/Datatypes/List.v#L561
Error: This command does not support this attribute: export. [unsupported-attributes,parsing]