### PR TITLE
Restore compatibility with fiat-crypto

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -12,6 +12,7 @@ ifneq (,$(filter 8.11%,$(COQ_VERSION)))
 	EXCLUDEFILES := \
 		$(wildcard $(SRCDIR)/coqutil/Ltac2Lib/*.v) \
 		$(wildcard $(SRCDIR)/coqutil/Tactics/fwd*.v) \
+		$(wildcard $(SRCDIR)/coqutil/Map/*.v) \
 		$(SRCDIR)/coqutil/Tactics/Records.v \
 		$(SRCDIR)/coqutil/Tactics/ParamRecords.v \
 		$(SRCDIR)/coqutil/Macros/ident_to_string.v \
@@ -19,15 +20,62 @@ ifneq (,$(filter 8.11%,$(COQ_VERSION)))
 		$(SRCDIR)/coqutil/Tactics/SafeSimpl.v \
 		$(SRCDIR)/coqutil/Word/ZifyLittleEndian.v \
 		$(SRCDIR)/coqutil/Datatypes/Inhabited.v \
+		$(SRCDIR)/coqutil/Datatypes/List.v \
+		$(SRCDIR)/coqutil/Datatypes/Prod.v \
+		$(SRCDIR)/coqutil/Datatypes/Inhabited.v \
+		$(SRCDIR)/coqutil/Word/Properties.v \
+		$(SRCDIR)/coqutil/Z/ZLib.v \
+		$(SRCDIR)/coqutil/Z/prove_Zeq_bitwise.v \
+		$(SRCDIR)/coqutil/Datatypes/ListSet.v \
+		$(SRCDIR)/coqutil/Map/Interface.v \
+		$(SRCDIR)/coqutil/Sorting/OrderToPermutation.v \
+		$(SRCDIR)/coqutil/Tactics/rewr.v \
+		$(SRCDIR)/coqutil/Word/BigEndian.v \
+		$(SRCDIR)/coqutil/Word/DebugWordEq.v \
+		$(SRCDIR)/coqutil/Word/LittleEndianList.v \
+		$(SRCDIR)/coqutil/Word/Naive.v \
+		$(SRCDIR)/coqutil/Word/LittleEndian.v \
+		$(SRCDIR)/coqutil/Word/SimplWordExpr.v \
 		#
 endif
 ifneq (,$(filter 8.12%,$(COQ_VERSION)))
 	EXCLUDEFILES := \
+		$(wildcard $(SRCDIR)/coqutil/Tactics/fwd*.v) \
+		$(wildcard $(SRCDIR)/coqutil/Map/*.v) \
 		$(SRCDIR)/coqutil/Tactics/Records.v \
 		$(SRCDIR)/coqutil/Tactics/ParamRecords.v \
 		$(SRCDIR)/coqutil/Macros/ident_to_string.v \
 		$(SRCDIR)/coqutil/Tactics/ident_of_string.v \
 		$(SRCDIR)/coqutil/Tactics/SafeSimpl.v \
+		$(SRCDIR)/coqutil/Word/ZifyLittleEndian.v \
+		$(SRCDIR)/coqutil/Datatypes/Prod.v \
+		$(SRCDIR)/coqutil/Datatypes/Inhabited.v \
+		$(SRCDIR)/coqutil/Word/Properties.v \
+		$(SRCDIR)/coqutil/Z/ZLib.v \
+		$(SRCDIR)/coqutil/Z/prove_Zeq_bitwise.v \
+		$(SRCDIR)/coqutil/Word/BigEndian.v \
+		$(SRCDIR)/coqutil/Word/DebugWordEq.v \
+		$(SRCDIR)/coqutil/Word/LittleEndianList.v \
+		$(SRCDIR)/coqutil/Word/Naive.v \
+		$(SRCDIR)/coqutil/Word/SimplWordExpr.v \
+		$(SRCDIR)/coqutil/Word/LittleEndian.v \
+		#
+endif
+ifneq (,$(filter 8.13%,$(COQ_VERSION)))
+	EXCLUDEFILES := \
+		$(wildcard $(SRCDIR)/coqutil/Tactics/fwd*.v) \
+		$(wildcard $(SRCDIR)/coqutil/Map/*.v) \
+		$(SRCDIR)/coqutil/Datatypes/Prod.v \
+		$(SRCDIR)/coqutil/Datatypes/Inhabited.v \
+		$(SRCDIR)/coqutil/Word/Properties.v \
+		$(SRCDIR)/coqutil/Z/ZLib.v \
+		$(SRCDIR)/coqutil/Z/prove_Zeq_bitwise.v \
+		$(SRCDIR)/coqutil/Word/BigEndian.v \
+		$(SRCDIR)/coqutil/Word/DebugWordEq.v \
+		$(SRCDIR)/coqutil/Word/LittleEndianList.v \
+		$(SRCDIR)/coqutil/Word/Naive.v \
+		$(SRCDIR)/coqutil/Word/SimplWordExpr.v \
+		$(SRCDIR)/coqutil/Word/LittleEndian.v \
 		$(SRCDIR)/coqutil/Word/ZifyLittleEndian.v \
 		#
 endif

--- a/src/coqutil/Z/bitblast.v
+++ b/src/coqutil/Z/bitblast.v
@@ -111,17 +111,17 @@ Module Z.
   (* 3 kinds of rewrite lemmas to turn (Z.testbit (Z.some_op ...)) into a boolean expression: *)
 
   (* 1) lemmas without any hypotheses (these are our favorites) *)
-  #[global] Hint Rewrite
+  Hint Rewrite
        Z.lor_spec
        Z.lxor_spec
        Z.land_spec
        Z.ldiff_spec
        Z.testbit_0_l
     : z_bitwise_no_hyps.
-  #[global] Hint Rewrite <-Z.ones_equiv : z_bitwise_no_hyps.
+  Hint Rewrite <-Z.ones_equiv : z_bitwise_no_hyps.
 
   (* 2) lemmas which have linear arithmetic hypotheses (good if we can solve the hypotheses) *)
-  #[global] Hint Rewrite
+  Hint Rewrite
        Z.shiftl_spec_low
        Z.shiftl_spec_alt
        Z.shiftl_spec
@@ -142,7 +142,7 @@ Module Z.
   (* 3) lemmas where we move some or all linear algebra preconditions into the conclusion
      by turning them into a boolean test
      (used as a fallback to make sure the bitblaster knows that it's worth case-destructing) *)
-  #[global] Hint Rewrite
+  Hint Rewrite
        Z.shiftl_spec'
        Z.shiftr_spec'
        Z.lnot_spec'


### PR DESCRIPTION
Fiat-Crypto uses Z.bitblast, so it needs to be compatible back to 8.11.
The other files that don't build with earlier versions of Coq are now
excluded.

Fixes #57 (once the auto-update runs)