### PR TITLE
Stop using revert dependent

### DIFF
--- a/src/coqutil/Datatypes/List.v
+++ b/src/coqutil/Datatypes/List.v
@@ -302,7 +302,7 @@ Section WithNonmaximallyInsertedA. Local Set Default Proof Using "All".
   Proof. induction n; auto. Qed.
   Lemma skipn_all n (xs : list A) (H : le (length xs) n) : skipn n xs = nil.
   Proof.
-    revert dependent xs; induction n, xs; cbn; auto; try blia; [].
+    generalize dependent xs; induction n, xs; cbn; auto; try blia; [].
     intros; rewrite IHn; trivial; blia.
   Qed.
 
@@ -431,7 +431,7 @@ Section WithNonmaximallyInsertedA. Local Set Default Proof Using "All".
     (H : forall i, nth_error xs i = nth_error ys i)
     : xs = ys.
   Proof.
-    revert dependent ys; induction xs; intros;
+    generalize dependent ys; induction xs; intros;
       pose proof H O as HO;
       destruct ys; cbn in HO; inversion HO; trivial.
     f_equal; eapply IHxs; exact (fun i => H (S i)).
@@ -994,7 +994,7 @@ Section WithNonmaximallyInsertedA. Local Set Default Proof Using "All".
       idx < length xs ->
       nth idx' (replace_nth idx xs v) d = v.
   Proof.
-    intros; subst; revert dependent idx; revert dependent xs.
+    intros; subst; generalize dependent idx; generalize dependent xs.
     induction xs; cbn; intros idx Hlt.
     - inversion Hlt.
     - destruct idx; simpl.

--- a/src/coqutil/Datatypes/ListSet.v
+++ b/src/coqutil/Datatypes/ListSet.v
@@ -226,7 +226,7 @@ Section ListSetProofs. Local Set Default Proof Using "All".
       In x (list_diff eeq l1 l2) ->
       In x l1.
   Proof.
-    intros. revert dependent l1. induction l2; simpl; intros.
+    intros. generalize dependent l1. induction l2; simpl; intros.
     - assumption.
     - eapply IHl2 in H. unfold list_diff in H. eapply In_removeb_weaken; eassumption.
   Qed.
@@ -241,7 +241,7 @@ Section ListSetProofs. Local Set Default Proof Using "All".
       NoDup l1 ->
       NoDup (list_diff eeq l1 l2).
   Proof.
-    intros. revert dependent l1. induction l2; simpl; intros.
+    intros. generalize dependent l1. induction l2; simpl; intros.
     - assumption.
     - eapply IHl2. eapply NoDup_removeb. assumption.
   Qed.
@@ -251,7 +251,7 @@ Section ListSetProofs. Local Set Default Proof Using "All".
                                    then list_diff eeq l1 l2
                                    else x :: list_diff eeq l1 l2.
   Proof.
-    intros. revert dependent l1.
+    intros. generalize dependent l1.
     induction l2; simpl; intros.
     - reflexivity.
     - destr (eeq a x).

--- a/src/coqutil/Ltac2Lib/Notations.v
+++ b/src/coqutil/Ltac2Lib/Notations.v
@@ -65,7 +65,7 @@ Abort.
 (* Still missing (https://github.com/coq/coq/issues/14289):
    - firstorder
    - intuition (and tauto)
-   - revert dependent
+   - generalize dependent
    - unshelve
    - cycle
    - notation for Std.rename, or always use Std.rename?

--- a/src/coqutil/Map/MapKeys.v
+++ b/src/coqutil/Map/MapKeys.v
@@ -14,7 +14,7 @@ Module map.
       (H:forall k' v', get m k' = Some v' -> f k = f k' -> get m k = get m k')
       : get (map_keys f m) (f k) = get m k.
     Proof.
-      revert dependent k.
+      generalize dependent k.
       cbv [map_keys].
       refine (fold_spec (fun m r => forall k,
         (forall k' v', get m k' = Some v' -> f k = f k' -> get m k = get m k') ->

--- a/src/coqutil/Map/OfFunc.v
+++ b/src/coqutil/Map/OfFunc.v
@@ -19,7 +19,7 @@ Module map.
     Lemma get_of_func_In k support (Hs : List.In k support)
       : get (of_func support) k = f k.
     Proof.
-      revert dependent support.
+      generalize dependent support.
       induction support.
       { firstorder idtac. }
       { destruct (key_eq_dec a k); intros [|]; subst;
@@ -32,7 +32,7 @@ Module map.
     Lemma get_of_func_Some_In k support v (H:get (of_func support) k = Some v)
       : List.In k support.
     Proof.
-      revert dependent support.
+      generalize dependent support.
       induction support.
       { cbn. rewrite get_empty. discriminate. }
       { destruct (key_eq_dec a k); subst; cbn [List.In of_func]; eauto.


### PR DESCRIPTION
See https://github.com/coq/coq/pull/17669. `revert dependent` is an alias for `generalize dependent` and is going away soon.