### PR TITLE
Adapt to coq/coq#18197 (List and Array fold argument order change)

### DIFF
--- a/src/coqutil/Datatypes/RecordSetters.v
+++ b/src/coqutil/Datatypes/RecordSetters.v
@@ -1,3 +1,5 @@
+Require coqutil.Ltac2Lib.List.
+
 Ltac eta X :=
   let s := constr:(ltac:(
         let x := fresh "x" in
@@ -519,7 +521,7 @@ Module record.
       match simp_term_check tp with
       | Some tp' => change $tp' in $x; true
       | None => progr
-      end) (Control.hyps ()) false.
+      end) false (Control.hyps ()).
 
   Ltac2 simp_hyps () :=
     if simp_hyps_bool_progress () then ()

--- a/src/coqutil/Datatypes/RecordSettersUsingExistingGetters.v
+++ b/src/coqutil/Datatypes/RecordSettersUsingExistingGetters.v
@@ -11,6 +11,7 @@ Require Import Coq.Program.Basics.
 Require Import Ltac2.Ltac2.
 Require Import Ltac2.Bool.
 Require Import coqutil.Ltac2Lib.Constr.
+Require coqutil.Ltac2Lib.List.
 Require Import coqutil.Tactics.RecordEta.
 Set Default Proof Mode "Classic".
 
@@ -471,7 +472,7 @@ Module record.
       match simp_term_check tp with
       | Some tp' => change $tp' in $x; true
       | None => progr
-      end) (Control.hyps ()) false.
+      end) false (Control.hyps ()).
 
   Ltac2 simp_hyps () :=
     if simp_hyps_bool_progress () then ()

--- a/src/coqutil/Ltac2Lib/List.v
+++ b/src/coqutil/Ltac2Lib/List.v
@@ -58,3 +58,21 @@ Ltac2 rec span(p: 'a -> bool)(xs: 'a list) :=
   | [] => ([], [])
   | h :: t => if p h then let (tk, dr) := span p t in (h :: tk, dr) else ([], xs)
   end.
+
+(* For compat between Coq before and after 8.19 (coq/coq#18197)
+
+   NB: these are the 8.19 version of the API so once <8.19 compat is
+   dropped they can just be deleted and references moved to the stdlib
+   versions. *)
+
+Ltac2 rec fold_right (f : 'a -> 'b -> 'b) (ls : 'a list) (a : 'b) : 'b :=
+  match ls with
+  | [] => a
+  | l :: ls => f l (fold_right f ls a)
+  end.
+
+Ltac2 rec fold_left (f : 'a -> 'b -> 'a) (a : 'a) (xs : 'b list) : 'a :=
+  match xs with
+  | [] => a
+  | x :: xs => fold_left f (f a x) xs
+  end.

--- a/src/coqutil/Ltac2Lib/String.v
+++ b/src/coqutil/Ltac2Lib/String.v
@@ -1,8 +1,8 @@
 Require Import Ltac2.Ltac2.
-Require coqutil.Ltac2Lib.Char.
+Require coqutil.Ltac2Lib.Char coqutil.Ltac2Lib.List.
 
 Ltac2 concat (ss : string list) : string :=
-  let l := List.fold_right Int.add 0 (List.map String.length ss) in
+  let l := List.fold_left Int.add 0 (List.map String.length ss) in
   let ret := String.make l (Char.of_int 0) in
   let rec loop (i : int) (ss : string list) : unit :=
     match ss with

--- a/src/coqutil/Tactics/fold_hyps.v
+++ b/src/coqutil/Tactics/fold_hyps.v
@@ -1,4 +1,5 @@
 Require Import Ltac2.Ltac2.
+Require coqutil.Ltac2Lib.List.
 
 Ltac2 fold_hyps_downwards(f: 'a -> ident -> constr -> 'a)(start: 'a) :=
   List.fold_left (fun acc p => let (h, obody, tp) := p in
@@ -6,7 +7,7 @@ Ltac2 fold_hyps_downwards(f: 'a -> ident -> constr -> 'a)(start: 'a) :=
                                | Some _ => acc
                                | None => f acc h tp
                                end)
-    (Control.hyps ()) start.
+    start (Control.hyps ()).
 
 Ltac2 fold_hyps_upwards(f: 'a -> ident -> constr -> 'a)(start: 'a) :=
   List.fold_right (fun p acc => let (h, obody, tp) := p in
@@ -14,7 +15,7 @@ Ltac2 fold_hyps_upwards(f: 'a -> ident -> constr -> 'a)(start: 'a) :=
                                 | Some _ => acc
                                 | None => f acc h tp
                                 end)
-    start (Control.hyps ()).
+    (Control.hyps ()) start.
 
 Ltac2 rec fold_left_cont(f: 'a -> 'e -> ('a -> unit) -> unit)(l: 'e list)(start: 'a)
   (k: 'a -> unit) :=


### PR DESCRIPTION
Should be backwards compatible (by vendoring the new definition until backward compat is dropped)