### PR TITLE
Use a more standard way of setting the default goal

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,4 +1,4 @@
-default_target: test
+.DEFAULT_GOAL := test
 
 .PHONY: clean force all notest test install uninstall validate
 


### PR DESCRIPTION
This works even if `default_goal` (or `.DEFAULT_GOAL`) is a file that exists, and even if `test` is not `PHONY`