### PR TITLE
Makefile: More robust printf invocation

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -15,7 +15,7 @@ SRC_VS ?= $(shell find $(SRC_DIR) -type f -name '*.v')
 TEST_VS ?= $(shell find $(TEST_DIR) -type f -name '*.v')
 
 _CoqProject:
-	printf -- '-R $(SRC_DIR)/coqutil/ coqutil\n-arg -w -arg unsupported-attributes\n' > _CoqProject
+	printf -- '-R %s/coqutil/ coqutil\n-arg -w -arg unsupported-attributes\n' '$(SRC_DIR)' > _CoqProject
 
 all: test
 


### PR DESCRIPTION
This way we can support people who are silly and name directories things like `\n` or `%s`