### PR TITLE
Add Eqb class, rewrite dbs, and some tactics from Pyrosome

### DIFF
--- a/src/coqutil/Datatypes/Option.v
+++ b/src/coqutil/Datatypes/Option.v
@@ -1,3 +1,5 @@
+Require Import Eqb InversionRewrite.
+
 Scheme Equality for option.
 Arguments option_beq {_} _ _ _.
 
@@ -65,3 +67,30 @@ Ltac inversion_option :=
        rename H into H';
        destruct (invert_eq_Some H') as [H ?]; subst H'
   end.
+
+Section __.
+  Context (A : Type)
+    `{Eqb_ok A}.
+
+  #[export] Instance option_eqb : Eqb (option A) :=
+    fun a b =>
+      match a, b with
+      | Some a, Some b => eqb a b
+      | None, None => true
+      | _, _ => false
+      end.
+
+  #[export] Instance option_eqb_ok : Eqb_ok option_eqb.
+  Proof.
+    unfold Eqb_ok, option_eqb.
+    unfold eqb at 1.
+    intros a b;
+      destruct a;
+      destruct b;
+      intros;
+      autorewrite with bool inversion;
+      intuition auto.
+    eqb_case a a0; congruence.
+  Qed.
+
+End __.

--- a/src/coqutil/Eqb.v
+++ b/src/coqutil/Eqb.v
@@ -17,41 +17,8 @@ Section __.
   Definition eqb_spec {Impl : Eqb} {Pf : @Eqb_ok Impl} : forall a b, if eqb a b then a = b else a <> b := Pf.
   Existing Class Eqb_ok.
 
-  
-  (* TODO: is the no-record version worth it here to avoid firstorder trouble? *)
-  Class DecidableEq :=
-    {
-      dec : forall (s1 s2 : A), {s1 = s2} + {s1 <> s2}
-    }.
-
-  (* Note: do not export. Should be declared as an instance only when no boolean implementation yet exists since it will likely have poor performance.   
-   *)
-  Instance eqb_from_decidable `{DecidableEq} : Eqb :=
-    fun a b => if dec a b then true else false.
-
-  
-  Instance eqb_from_decidable_ok `{DecidableEq} : Eqb_ok.
-  Proof.
-    intros a b.
-    unfold eqb, eqb_from_decidable.
-    destruct (dec a b); auto.
-  Qed.
-
 
   Context `{Eqb_ok}.
-  
-  (* Note: do not export. This instance should not be expected to compute, since it depends on a lemma
-     that is probably defined with Qed. To emphasize this, we define this instance with Qed as well.
-     Thus, it should be used with caution.
-   *)
-  Instance decidable_from_eqb_ok : DecidableEq.
-  Proof.
-    constructor; intros.
-    specialize (H0 s1 s2).
-    revert H0.
-    case_match;
-      intros; subst; eauto.
-  Qed.
 
 
   Lemma eqb_prop_iff
@@ -98,7 +65,6 @@ End __.
 Arguments eqb {A}%type_scope {Impl} _ _.
 Arguments Eqb_ok {A}%type_scope H.
 Arguments eqb_spec {A}%type_scope {Impl Pf} a b.
-Arguments dec {A}%type_scope {DecidableEq} s1 s2.
    
 #[export] Hint Rewrite eqb_prop_iff using solve[typeclasses eauto] : bool.
 #[export] Hint Rewrite eqb_refl_true using solve[typeclasses eauto] : bool.

--- a/src/coqutil/Eqb.v
+++ b/src/coqutil/Eqb.v
@@ -1,0 +1,171 @@
+Require Import Tactics.case_match Datatypes.Bool Decidable Datatypes.String Uint63.
+(*
+  A typeclass for boolean equality
+ *)
+
+Section __.
+  Context (A : Type).
+
+  (* Not defined as a record so that firstorder doesn't mess with it*)
+  Definition Eqb := A -> A -> bool.
+  Definition eqb {Impl : Eqb} : A -> A -> bool := Impl.
+  Existing Class Eqb.
+
+  
+  (* Not defined as a record so that firstorder doesn't mess with it*)
+  Definition Eqb_ok `{Eqb} := forall a b, if eqb a b then a = b else a <> b.
+  Definition eqb_spec {Impl : Eqb} {Pf : @Eqb_ok Impl} : forall a b, if eqb a b then a = b else a <> b := Pf.
+  Existing Class Eqb_ok.
+
+  
+  (* TODO: is the no-record version worth it here to avoid firstorder trouble? *)
+  Class DecidableEq :=
+    {
+      dec : forall (s1 s2 : A), {s1 = s2} + {s1 <> s2}
+    }.
+
+  (* Note: do not export. Should be declared as an instance only when no boolean implementation yet exists since it will likely have poor performance.   
+   *)
+  Instance eqb_from_decidable `{DecidableEq} : Eqb :=
+    fun a b => if dec a b then true else false.
+
+  
+  Instance eqb_from_decidable_ok `{DecidableEq} : Eqb_ok.
+  Proof.
+    intros a b.
+    unfold eqb, eqb_from_decidable.
+    destruct (dec a b); auto.
+  Qed.
+
+
+  Context `{Eqb_ok}.
+  
+  (* Note: do not export. This instance should not be expected to compute, since it depends on a lemma
+     that is probably defined with Qed. To emphasize this, we define this instance with Qed as well.
+     Thus, it should be used with caution.
+   *)
+  Instance decidable_from_eqb_ok : DecidableEq.
+  Proof.
+    constructor; intros.
+    specialize (H0 s1 s2).
+    revert H0.
+    case_match;
+      intros; subst; eauto.
+  Qed.
+
+
+  Lemma eqb_prop_iff
+    : forall a b, Is_true (eqb a b) <-> a = b.
+  Proof.
+    intros a b.
+    specialize (H0 a b); revert H0.
+    case_match;
+      intros; subst; cbn; intuition eauto.
+  Qed.
+
+  
+  Lemma eqb_refl_true
+    : forall a, eqb a a = true.
+  Proof.
+    intro a.
+    specialize (H0 a a); revert H0.
+    case_match;
+      intros; subst; cbn; intuition eauto.
+  Qed.
+
+  (* Useful as a rewriting hint, but not added by default.
+     Hint Rewrite eqb_ineq_false using (try typeclasses eauto; (left || right); assumption) : bool.
+   *)
+  Lemma eqb_ineq_false
+    : forall a b, ((a <> b) \/ (b <> a)) -> eqb a b = false.
+  Proof.
+    intros a b Hneq.
+    specialize (H0 a b); revert H0.
+    case_match;
+      intros; subst; cbn; intuition eauto.
+  Qed.
+
+  #[export] Instance eqb_boolspec
+    : forall x y : A, BoolSpec (x = y) (x <> y) (eqb x y).
+  Proof.
+    intros.
+    pose proof (eqb_spec x y).
+    destruct (eqb x y); constructor; eauto.
+  Qed.
+  
+End __.
+
+Arguments eqb {A}%_type_scope {Impl} _ _.
+Arguments Eqb_ok {A}%_type_scope H.
+Arguments eqb_spec {A}%_type_scope {Impl Pf} a b.
+Arguments dec {A}%_type_scope {DecidableEq} s1 s2.
+   
+#[export] Hint Rewrite eqb_prop_iff using solve[typeclasses eauto] : bool.
+#[export] Hint Rewrite eqb_refl_true using solve[typeclasses eauto] : bool.
+
+
+(* Instances for some standard library types *)
+
+#[export] Instance bool_eqb : Eqb bool := Bool.eqb.
+
+#[export] Instance bool_eqb_ok : Eqb_ok bool_eqb.
+Proof.
+  intros a b.
+  unfold eqb, bool_eqb.
+  destruct (Coq.Bool.Bool.eqb_spec a b); eauto.
+Qed.
+
+
+#[export] Instance string_Eqb : Eqb string := String.eqb.
+
+#[export] Instance string_Eqb_ok : Eqb_ok string_Eqb.
+Proof.
+  intros a b.
+  unfold eqb, string_Eqb.
+  destruct (String.eqb_spec a b); auto.
+Qed.
+
+
+#[export] Instance nat_eqb : Eqb nat := Nat.eqb.
+
+#[export] Instance nat_eqb_ok : Eqb_ok nat_eqb.
+Proof.
+  intros a b.
+  unfold eqb, nat_eqb.
+  destruct (Decidable.Nat.eqb_spec a b); eauto.
+Qed.
+
+#[export] Instance int_eqb : Eqb int := Uint63.eqb.
+
+#[export] Instance int_eqb_ok : Eqb_ok int_eqb.
+Proof.
+  intros a b.
+  unfold eqb, int_eqb.
+  case_match; [eapply Uint63.eqb_spec| eapply eqb_false_spec]; eauto.
+Qed.
+
+
+Ltac eqb_case i j :=
+  pose proof (eqb_spec i j); destruct (eqb i j);[ try (subst i || subst j) |].
+
+Section Tests.
+
+  Goal (forall x : nat, Is_true (eqb x 5) -> x = 5).
+  Proof.
+    intros x.
+    eqb_case x 5; cbn; tauto.
+  Abort.
+  
+  Goal (forall x : nat, Is_true (eqb 5 x) -> x = 5).
+  Proof.
+    intros x.
+    eqb_case 5 x; cbn; tauto.
+  Abort.
+  
+  Goal (forall x : nat, Is_true (eqb 5 6) -> 6 = 5).
+  Proof.
+    intros x.
+    eqb_case 5 6; cbn; [congruence | tauto].
+  Abort.   
+
+End Tests.

--- a/src/coqutil/Eqb.v
+++ b/src/coqutil/Eqb.v
@@ -95,10 +95,10 @@ Section __.
   
 End __.
 
-Arguments eqb {A}%_type_scope {Impl} _ _.
-Arguments Eqb_ok {A}%_type_scope H.
-Arguments eqb_spec {A}%_type_scope {Impl Pf} a b.
-Arguments dec {A}%_type_scope {DecidableEq} s1 s2.
+Arguments eqb {A}%type_scope {Impl} _ _.
+Arguments Eqb_ok {A}%type_scope H.
+Arguments eqb_spec {A}%type_scope {Impl Pf} a b.
+Arguments dec {A}%type_scope {DecidableEq} s1 s2.
    
 #[export] Hint Rewrite eqb_prop_iff using solve[typeclasses eauto] : bool.
 #[export] Hint Rewrite eqb_refl_true using solve[typeclasses eauto] : bool.

--- a/src/coqutil/InversionRewrite.v
+++ b/src/coqutil/InversionRewrite.v
@@ -1,0 +1,70 @@
+Require Import Tactics.ProveInversion.
+
+(* A database of inversion rules for use in autorewrite *)
+
+
+(* Natural number inversions *)
+  
+Lemma invert_eq_0_S x : 0 = S x <-> False.
+Proof. prove_inversion_lemma. Qed.
+#[export] Hint Rewrite invert_eq_0_S : inversion.
+
+Lemma invert_eq_S_0 x : S x = 0 <-> False.
+Proof. prove_inversion_lemma. Qed.
+#[export] Hint Rewrite invert_eq_S_0 : inversion.
+
+Lemma invert_eq_S_S x y : S x = S y <-> x = y.
+Proof. prove_inversion_lemma. Qed.
+#[export] Hint Rewrite invert_eq_S_S : inversion.
+  
+
+Section __.
+  Context (A : Type).
+
+  (* reflexivity *)
+  Lemma invert_reflexivity (x : A)
+    : x = x <-> True.
+  Proof. prove_inversion_lemma. Qed.
+
+  (* Option inversions *)
+
+  Lemma invert_eq_none_some (x : A)
+    : None = Some x <-> False.
+  Proof. prove_inversion_lemma. Qed.
+
+  Lemma invert_eq_some_none (x : A)
+    : Some x = None <-> False.
+  Proof. prove_inversion_lemma. Qed.
+  
+  Lemma invert_eq_some_some (x y : A)
+    : Some x = Some y <-> x = y.
+  Proof. prove_inversion_lemma. Qed.
+
+
+  (* List inversions *)
+  
+  Lemma invert_eq_cons_nil (e:A) es : cons e es = nil <-> False.
+  Proof. prove_inversion_lemma. Qed.
+  
+  Lemma invert_eq_nil_cons (e:A) es : nil = cons e es <-> False.
+  Proof. prove_inversion_lemma. Qed.
+  
+  Lemma invert_eq_cons_cons (e e':A) es es'
+    : cons e es = cons e' es' <-> e = e' /\ es = es'.
+  Proof. prove_inversion_lemma. Qed.
+
+End __.
+
+
+#[export] Hint Rewrite pair_equal_spec : inversion.
+
+#[export] Hint Rewrite invert_reflexivity : inversion.
+
+#[export] Hint Rewrite invert_eq_none_some : inversion.
+#[export] Hint Rewrite invert_eq_some_none : inversion.
+#[export] Hint Rewrite invert_eq_some_some : inversion.
+
+
+#[export] Hint Rewrite invert_eq_cons_nil : inversion.
+#[export] Hint Rewrite invert_eq_nil_cons : inversion.
+#[export] Hint Rewrite invert_eq_cons_cons : inversion.

--- a/src/coqutil/PropRewrite.v
+++ b/src/coqutil/PropRewrite.v
@@ -1,0 +1,70 @@
+(*
+  A database of basic rewrites for greedily simplifying propositions during autorewrite.
+ *)
+
+Lemma eq_refl_inv A (x : A) : x = x <-> True.
+Proof.
+  intuition congruence.
+Qed.
+#[export] Hint Rewrite eq_refl_inv : rw_prop.
+
+Lemma not_True : ~ True <-> False.
+Proof.
+  intuition congruence.
+Qed.
+#[export] Hint Rewrite not_True : rw_prop.
+
+Lemma not_False : ~ False <-> True.
+Proof.
+  intuition congruence.
+Qed.
+#[export] Hint Rewrite not_False : rw_prop.
+
+
+Lemma False_and P : False /\ P <-> False.
+Proof.
+  intuition congruence.
+Qed.
+#[export] Hint Rewrite False_and : rw_prop.
+
+Lemma and_False P : P /\ False <-> False.
+Proof.
+  intuition congruence.
+Qed.
+#[export] Hint Rewrite and_False : rw_prop.
+
+Lemma False_or P : False \/ P <-> P.
+Proof.
+  intuition congruence.
+Qed.
+#[export] Hint Rewrite False_or : rw_prop.
+
+Lemma or_False P : P \/ False <-> P.
+Proof.
+  intuition congruence.
+Qed.
+#[export] Hint Rewrite or_False : rw_prop.
+
+Lemma True_and P : True /\ P <-> P.
+Proof.
+  intuition congruence.
+Qed.
+#[export] Hint Rewrite True_and : rw_prop.
+
+Lemma and_True P : P /\ True <-> P.
+Proof.
+  intuition congruence.
+Qed.
+#[export] Hint Rewrite and_True : rw_prop.
+
+Lemma True_or P : True \/ P <-> True.
+Proof.
+  intuition congruence.
+Qed.
+#[export] Hint Rewrite True_or : rw_prop.
+
+Lemma or_True P : P \/ True <-> True.
+Proof.
+  intuition congruence.
+Qed.
+#[export] Hint Rewrite or_True : rw_prop.

--- a/src/coqutil/Tactics/case_match.v
+++ b/src/coqutil/Tactics/case_match.v
@@ -1,0 +1,89 @@
+(*
+  The `case_match` tactic destructs the first non-match scrutinee of the first match it finds in (first) the goal or (second) the hypotheses.
+ *)
+
+Ltac case_match' c :=
+  lazymatch c with
+  | context [match ?c' with _ => _ end] => case_match' c'
+  | _ =>
+      tryif is_var c then destruct c
+      else let case_eqn := fresh "case_match_eqn" in
+           destruct c eqn:case_eqn
+  end.
+
+Ltac case_match :=
+  match goal with
+  | |- context [ match ?e with
+                 | _ => _
+                 end ] => case_match' e
+  | H : context [ match ?e with
+                 | _ => _
+                 end ] |- _ => case_match' e
+  end.
+
+(* does not look at the hypotheses *)
+Ltac case_match_goal :=
+  match goal with
+  | |- context [ match ?e with
+                 | _ => _
+                 end ] => case_match' e
+  end.
+
+Section Tests.
+
+  Goal forall x,
+      match match x with
+            | S _ => 1
+            | O => 0
+            end with
+      | S _ => True
+      | O => True
+      end.
+  Proof.
+    intro x.
+    case_match_goal; exact I.
+    Undo.
+    case_match; exact I.
+  Abort.
+  
+  Goal forall x : bool,
+      x = if if x then false else true then false else true.
+  Proof.
+    intro x.
+    case_match_goal; reflexivity.
+    Undo.
+    case_match; reflexivity.
+  Abort.
+  
+  Goal forall x : bool,
+      x = if x then true else false.
+  Proof.
+    intro x.
+    case_match_goal; reflexivity.
+    Undo.
+    case_match; reflexivity.
+  Abort.
+
+  Goal forall x y : bool,
+      x = (if if y then false else true then false else true) ->
+      x = y.
+  Proof.
+    intros x y H.
+    Fail (case_match_goal; congruence).
+    case_match; congruence.
+  Abort.
+
+  
+  Goal forall x : bool,
+      x = if andb x x then true else false.
+  Proof.
+    intro x.
+    case_match.
+    {
+      apply andb_prop in case_match_eqn.
+      intuition tauto.
+    }
+    { shelve. }
+  Abort.
+
+End Tests.

--- a/src/coqutil/Tactics/safe_invert.v
+++ b/src/coqutil/Tactics/safe_invert.v
@@ -1,0 +1,39 @@
+(* Performs inversion on H exactly when 
+    either: 
+    - no constructors can produce H and the goal is solved
+    - exactly one constructor can produce H and inversion
+      makes progress
+ *)
+Ltac safe_invert H :=
+  let t := type of H in
+  inversion H; clear H;
+  let n := numgoals in
+  guard n <= 1;
+  lazymatch goal with
+  | [ H' : t|-_]=>
+    fail "safe_invert did not make progress"
+  | _ => subst
+  end.
+
+Section Tests.
+  
+  Goal False -> False.
+  Proof.
+    intro H.
+    safe_invert H.
+    Fail idtac.
+  Abort.
+    
+  Goal forall n m, S n = S m -> n = m.
+  Proof.
+    intros n m H.
+    safe_invert H.
+    reflexivity.
+  Abort.
+
+  Goal forall x y : nat + bool, x = y -> x = inl 0.
+  Proof.
+    intros x y H.
+    Fail safe_invert H.    
+  Abort.
+End Tests.


### PR DESCRIPTION
Adds an Eqb class for types with boolean equality, a set of lemmas gathered into a rewrite database for greedy proposition simplification, another rewrite database for datatype inversion, and some generic tactics for inversion and case analysis.