### PR TITLE
Add From coqutil to imports

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -13,7 +13,7 @@ TEST_VS := $(shell find $(TEST_DIR) -type f -name '*.v')
 # We auto-update _CoqProject and _CoqProject.notest,
 # but only change their timestamp if the set of files that they list changed
 
-PRINT_COQPROJECT_ARGS := printf -- '-R %s/coqutil/ coqutil\n' '$(SRC_DIR)'
+PRINT_COQPROJECT_ARGS := printf -- '-Q %s/coqutil/ coqutil\n' '$(SRC_DIR)'
 PRINT_SRC_VS := printf -- '%s\n' $(sort $(SRC_VS))
 PRINT_TEST_VS := printf -- '%s\n' $(sort $(TEST_VS))
 PRINT_COQPROJECT_NOTEST := { $(PRINT_COQPROJECT_ARGS); $(PRINT_SRC_VS); }

--- a/src/coqutil/Datatypes/Option.v
+++ b/src/coqutil/Datatypes/Option.v
@@ -1,4 +1,4 @@
-Require Import Eqb InversionRewrite.
+From coqutil Require Import Eqb InversionRewrite.
 
 Scheme Equality for option.
 Arguments option_beq {_} _ _ _.

--- a/src/coqutil/Eqb.v
+++ b/src/coqutil/Eqb.v
@@ -1,4 +1,5 @@
-Require Import Tactics.case_match Datatypes.Bool Decidable Datatypes.String Uint63.
+From coqutil Require Import Tactics.case_match Datatypes.Bool Decidable Datatypes.String.
+Require Import Uint63.
 (*
   A typeclass for boolean equality
  *)

--- a/src/coqutil/InversionRewrite.v
+++ b/src/coqutil/InversionRewrite.v
@@ -1,4 +1,4 @@
-Require Import Tactics.ProveInversion.
+From coqutil Require Import Tactics.ProveInversion.
 
 (* A database of inversion rules for use in autorewrite *)
 


### PR DESCRIPTION
Perennial builds coqutil with a _CoqProject that uses `-Q coqutil/src coqutil` rather than `-R`, which makes these `From coqutil` qualifiers required.

We could change Perennial but I think these are good style anyway and this is the first time this has been a problem.