### PR TITLE
Suppress Undo warning in batch mode

### DIFF
--- a/src/coqutil/Tactics/case_match.v
+++ b/src/coqutil/Tactics/case_match.v
@@ -31,6 +31,8 @@ Ltac case_match_goal :=
 
 Section Tests.
 
+  #[local] Set Warnings "-undo-batch-mode".
+
   Goal forall x,
       match match x with
             | S _ => 1


### PR DESCRIPTION
There are many other warnings by default in coqutil but this was the only one annoying me.