### PR TITLE
Add opam file

### DIFF
--- a/coqutil.opam
+++ b/coqutil.opam
@@ -1,0 +1,23 @@
+opam-version: "2.0"
+name: "coqutil"
+version: "dev"
+maintainer: "Samuel Gruetter <s.gruetter@inf.ethz.ch>"
+authors: ["coqutil Authors"]
+homepage: "https://github.com/mit-plv/coqutil"
+bug-reports: "https://github.com/mit-plv/coqutil/issues"
+dev-repo: "git+https://github.com/mit-plv/coqutil.git"
+license: "MIT"
+synopsis: "Coq library for tactics, basic definitions, sets, maps"
+description: """
+This package provides utilities and libraries that assist with the development
+and verification of proofs using the Coq proof assistant.
+"""
+depends: [
+  "coq" {>= "8.18"}
+]
+build: [
+  ["%{make}%" "all" "-j%{jobs}%"]
+]
+install: [
+  ["%{make}%" "install"]
+]


### PR DESCRIPTION
In order to depend on coqutil via opam, it needs an opam file.

With just this in place it is possible to use pin-depends and the git URL to add the dependency, even without adding the opam file to an archive like https://github.com/rocq-prover/opam.