### PR TITLE
backtrack less in ecancel

### DIFF
--- a/src/coqutil/Tactics/ltac_list_ops.v
+++ b/src/coqutil/Tactics/ltac_list_ops.v
@@ -9,6 +9,17 @@ Ltac map_with_ltac f l :=
   end.
 
 (* for lists with concrete structure/length, but elements that should not be cbv'd *)
+Ltac list_get l i :=
+  lazymatch l with
+  | cons ?a ?l =>
+    lazymatch i with
+    | O  => a
+    | S ?i => list_get l i
+    end
+  | _ => fail "list_get nil" i
+  end.
+
+(* for lists with concrete structure/length, but elements that should not be cbv'd *)
 Ltac list_length l :=
   lazymatch l with
   | nil => constr:(O)


### PR DESCRIPTION
The seemingly looping example now fails in <1s.

According to LtacProf, there are now 16 (linear #?) calls to ecancel_step_at and spends almost 90% of tine in 15k calls within syntactic_unify_deltavar. However, the first line of LtacProf output looks suspect, so I am not sure how much to trust it...

```
total time:      1.408s

 tactic                                        local  total   calls       max
─────────────────────────────────────────────┴──────┴──────┴───────┴─────────┘
─ecancel_assumption ------------------------- 100.0% 100.0%     225    1.408s
─ecancel ------------------------------------   0.0%  97.7%       1    1.375s
─ecancel_steps_at ---------------------------  77.1%  89.6%      24    0.735s
─ecancel_step_at ----------------------------   0.1%  89.5%      16    0.121s
─syntactic_unify._syntactic_unify_deltavar --  87.7%  88.2%   15320    0.020s
─ltac_list_ops.find_syntactic_unify_deltavar   73.2%  85.5%       0    0.120s
─is_evar ------------------------------------  10.4%  10.4%   30955    0.000s
─is_var -------------------------------------  10.2%  10.2%   31386    0.000s
─cancel -------------------------------------   0.0%   6.6%       2    0.092s
─cancel_seps_at_indices ---------------------   5.7%   5.7%      52    0.012s
─cancel_seps --------------------------------   0.0%   5.6%       2    0.079s
─simple refine (uconstr) --------------------   5.4%   5.4%      13    0.011s
─cancel_step --------------------------------   0.1%   5.2%       7    0.024s
─constr_eq ----------------------------------   2.2%   2.2%    8057    0.001s

 tactic                                        local  total   calls       max
─────────────────────────────────────────────┴──────┴──────┴───────┴─────────┘
─ecancel_assumption ------------------------- 100.0% 100.0%     225    1.408s
└ecancel ------------------------------------   0.0%  97.7%       1    1.375s
 ├─ecancel_steps_at -------------------------  77.1%  89.6%      24    0.735s
 │└ecancel_step_at --------------------------   0.1%  89.5%      16    0.121s
 │ ├─ltac_list_ops.find_syntactic_unify_delta  73.2%  85.5%       0    0.120s
 │ │└syntactic_unify._syntactic_unify_deltava  85.2%  85.3%   14874    0.020s
 │ │ ├─is_evar ------------------------------  10.1%  10.1%   30054    0.000s
 │ │ └─is_var -------------------------------   9.9%   9.9%   30194    0.000s
 │ └─cancel_seps_at_indices -----------------   3.7%   3.7%      40    0.012s
 │  └simple refine (uconstr) ----------------   3.5%   3.5%      10    0.011s
 └─cancel -----------------------------------   0.0%   6.6%       2    0.092s
  └cancel_seps ------------------------------   0.0%   5.6%       2    0.079s
  └cancel_step ------------------------------   0.1%   5.2%       7    0.024s
```

Fixes https://github.com/mit-plv/coqutil/issues/142