### PR TITLE
Update opam name field to coq-coqutil

### DIFF
--- a/coq-coqutil.opam
+++ b/coq-coqutil.opam
@@ -1,5 +1,5 @@
 opam-version: "2.0"
-name: "coqutil"
+name: "coq-coqutil"
 version: "dev"
 maintainer: "Samuel Gruetter <s.gruetter@inf.ethz.ch>"
 authors: ["coqutil Authors"]


### PR DESCRIPTION
Hello!

I use coqutil through perennial and build everything with the nix flake. While updating everything today, I noticed the build was failing and traced it back to the opam nix framework being dependent on the `name` field in coqutil's opam file being set correctly. 

While the opam file itself was renamed, the `name` field inside the file wasn't updated.