### PR TITLE
Map.Interface, Word.Interface: Set Universe Polymorphism

### DIFF
--- a/src/coqutil/Map/Interface.v
+++ b/src/coqutil/Map/Interface.v
@@ -1,3 +1,4 @@
+Set Universe Polymorphism.
 Require Import coqutil.sanity.
 Require Import coqutil.Datatypes.HList.
 Require Import coqutil.Datatypes.List.

--- a/src/coqutil/Word/Interface.v
+++ b/src/coqutil/Word/Interface.v
@@ -1,3 +1,4 @@
+Set Universe Polymorphism.
 (* Specification of two's complement machine words wrt Z *)
 
 Require Import Coq.ZArith.BinIntDef Coq.ZArith.BinInt.


### PR DESCRIPTION
## Summary

Both `Map.Interface` and `Word.Interface` define typeclasses (`map`, `word`) that downstream consumers parameterize over. Without `Set Universe Polymorphism`, every instance is locked at a fixed universe level, which forces universe-bumping casts at every callsite — and outright blocks composition for downstream code that needs to instantiate at multiple universe levels.

## Motivation

Jasmin extraction (via the `JasminBridge` in AUCurves) and bedrock2-WP proofs both need to instantiate `map.rep` and `word.rep` at universe levels selected by the surrounding context. With monomorphic interfaces this fails with cryptic "universe inconsistency" errors that bisect to the interface declaration site.

## Diff

```diff
+ Set Universe Polymorphism.
  Require Import coqutil.sanity.
  ...
```

(Identical one-line additions on `Map.Interface.v` and `Word.Interface.v`.)

## Test plan

- [x] Clean rebuild of bedrock2 + downstream Rocq tree (AUCurves) with no regressions.
- [x] Header-only annotation, no proof bodies modified.