### PR TITLE
make Forall2_impl_strong more eauto-friendly

### DIFF
--- a/src/coqutil/Datatypes/List.v
+++ b/src/coqutil/Datatypes/List.v
@@ -832,14 +832,10 @@ Section WithNonmaximallyInsertedA. Local Set Default Proof Using "All".
   Qed.
 
   Lemma Forall2_impl_strong {B} (R1 R2 : A -> B -> Prop) xs ys :
+    Forall2 R1 xs ys ->
     (forall x y, R1 x y -> In x xs -> In y ys -> R2 x y) ->
-    Forall2 R1 xs ys -> Forall2 R2 xs ys.
-  Proof.
-    revert ys; induction xs; destruct ys; intros;
-      match goal with H : Forall2 _ _ _ |- _ =>
-                      inversion H; subst; clear H end;
-      constructor; eauto using in_eq, in_cons.
-  Qed.
+    Forall2 R2 xs ys.
+  Proof. induction 1; simpl; eauto 9. Qed.
 
   Lemma Forall2_app_inv {B} (R : A -> B -> Prop)
         xs1 xs2 ys1 ys2 :


### PR DESCRIPTION
Switching the hypothesis order makes eauto behave better.  For example:

```
From Stdlib Require Import List.

Lemma Forall2_impl_strong {A B} (R1 R2 : A -> B -> Prop) xs ys :
    Forall2 R1 xs ys ->
    (forall x y, R1 x y -> In x xs -> In y ys -> R2 x y) ->
    Forall2 R2 xs ys.
Proof. induction 1; simpl; eauto 9. Qed.

Lemma unfriendly_Forall2_impl_strong {A B} (R1 R2 : A -> B -> Prop) xs ys :
    (forall x y, R1 x y -> In x xs -> In y ys -> R2 x y) ->
    Forall2 R1 xs ys ->
    Forall2 R2 xs ys.
Proof. induction 2; simpl in *; eauto 9. Qed.

Lemma test A (x y : list A) P1 P2 :
  (P1 -> P2) ->
  Forall2 (fun _ _ => P1) x y ->
  Forall2 (fun _ _ => P2) x y.
Proof.
  Fail solve [eauto using unfriendly_Forall2_impl_strong].
  eauto using Forall2_impl_strong.
Qed.
```

Switching the hypothesis order also makes `eapply Forall2_impl_strong; eauto.` more likely to do something reasonable.

Note that Stdlib `Forall2_impl` follows the same pattern as `unfriendly_Forall2_impl_strong`, which is unfortunate.

Part of the reason I'm making this pull request is that I'm curious what the policy is about merging not-entirely-backwards-compatible changes.